### PR TITLE
feat(fluid): P4.5 vertical layering with density-based swap

### DIFF
--- a/crates/core/src/chunk.rs
+++ b/crates/core/src/chunk.rs
@@ -119,6 +119,8 @@ pub struct ChunkData {
     // ── Fluid fields (read = authoritative, write = derived buffer) ─────
     #[serde(with = "box_array_liquid")]
     pub liquid_kind: Box<[LiquidId; CHUNK_AREA]>,
+    #[serde(skip, default = "default_liquid_kind_box")]
+    pub liquid_kind_write: Box<[LiquidId; CHUNK_AREA]>,
 
     #[serde(with = "box_array_u8")]
     pub liquid_amount_read: Box<[u8; CHUNK_AREA]>,
@@ -160,6 +162,7 @@ impl ChunkData {
                 .unwrap(),
             temp: default_zero_i16_box(),
             liquid_kind: default_liquid_kind_box(),
+            liquid_kind_write: default_liquid_kind_box(),
             liquid_amount_read: default_zero_u8_box(),
             liquid_amount_write: default_zero_u8_box(),
             liquid_temp_read: default_zero_i16_box(),
@@ -175,6 +178,7 @@ impl ChunkData {
     /// Swap read ↔ write buffers for all double-buffered fluid fields.
     /// Called once per tick in PostTick.
     pub fn swap_buffers(&mut self) {
+        std::mem::swap(&mut self.liquid_kind, &mut self.liquid_kind_write);
         std::mem::swap(&mut self.liquid_amount_read, &mut self.liquid_amount_write);
         std::mem::swap(&mut self.liquid_temp_read, &mut self.liquid_temp_write);
         std::mem::swap(&mut self.pressure_read, &mut self.pressure_write);

--- a/crates/sim-fluid/src/lib.rs
+++ b/crates/sim-fluid/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod fluid_ca;
 pub mod snapshot;
+pub mod vertical_flow;
 
 use bevy_ecs::prelude::Resource;
 use bitflags::bitflags;
@@ -11,7 +12,7 @@ use tile_core::material::MaterialId;
 pub use snapshot::LiquidSnapshot;
 
 /// Bevy plugin for fluid simulation.
-/// System order: snapshot_liquid → fluid_step_local → swap_buffers_system.
+/// System order (Bibel §9.12): snapshot → horizontal → vertical → swap.
 pub struct FluidPlugin;
 
 impl bevy_app::Plugin for FluidPlugin {
@@ -24,6 +25,7 @@ impl bevy_app::Plugin for FluidPlugin {
             (
                 snapshot::snapshot_liquid,
                 fluid_ca::fluid_step_local,
+                vertical_flow::liquid_vertical_flow,
                 fluid_ca::swap_buffers_system,
             )
                 .chain(),

--- a/crates/sim-fluid/src/snapshot.rs
+++ b/crates/sim-fluid/src/snapshot.rs
@@ -2,6 +2,7 @@ use bevy_ecs::prelude::*;
 use std::collections::HashMap;
 use tile_core::chunk::ChunkData;
 use tile_core::coords::{CHUNK_AREA, ChunkCoord};
+use tile_core::liquid::{LIQ_NONE, LiquidId};
 use tile_core::material::{MAT_AIR, MaterialId};
 
 /// Read-only frozen copy of all chunks' liquid state, built once per tick in PreTick.
@@ -11,6 +12,7 @@ use tile_core::material::{MAT_AIR, MaterialId};
 #[derive(Resource, Default)]
 pub struct LiquidSnapshot {
     amounts: HashMap<ChunkCoord, Box<[u8; CHUNK_AREA]>>,
+    kinds: HashMap<ChunkCoord, Box<[LiquidId; CHUNK_AREA]>>,
     terrain: HashMap<ChunkCoord, Box<[MaterialId; CHUNK_AREA]>>,
 }
 
@@ -19,10 +21,21 @@ impl LiquidSnapshot {
         self.amounts.get(&coord).map_or(0, |a| a[local_idx])
     }
 
+    pub fn get_kind(&self, coord: ChunkCoord, local_idx: usize) -> LiquidId {
+        self.kinds.get(&coord).map_or(LIQ_NONE, |k| k[local_idx])
+    }
+
     pub fn is_passable(&self, coord: ChunkCoord, local_idx: usize) -> bool {
         self.terrain
             .get(&coord)
             .map_or(false, |t| t[local_idx] == MAT_AIR)
+    }
+
+    /// True if chunk exists in snapshot and has any non-zero liquid amount.
+    pub fn chunk_has_liquid(&self, coord: ChunkCoord) -> bool {
+        self.amounts
+            .get(&coord)
+            .map_or(false, |a| a.iter().any(|&v| v > 0))
     }
 
     /// True if any of the 4 horizontal neighbor chunks exist in the snapshot.
@@ -48,16 +61,34 @@ impl LiquidSnapshot {
         .iter()
         .any(|nb| self.amounts.contains_key(nb))
     }
+
+    /// True if chunk above (cz+1) or below (cz-1) exists in the snapshot.
+    pub fn has_vertical_neighbor(&self, coord: ChunkCoord) -> bool {
+        let above = ChunkCoord {
+            cz: coord.cz + 1,
+            ..coord
+        };
+        let below = ChunkCoord {
+            cz: coord.cz - 1,
+            ..coord
+        };
+        self.amounts.contains_key(&above) || self.amounts.contains_key(&below)
+    }
 }
 
-/// PreTick system: freeze liquid_amount_read and terrain from every chunk.
+/// PreTick system: freeze liquid_amount_read, liquid_kind, and terrain from every chunk.
 pub fn snapshot_liquid(mut snapshot: ResMut<LiquidSnapshot>, chunks: Query<&ChunkData>) {
     snapshot.amounts.clear();
+    snapshot.kinds.clear();
     snapshot.terrain.clear();
     for chunk in chunks.iter() {
         let mut amounts = Box::new([0u8; CHUNK_AREA]);
         amounts.copy_from_slice(&*chunk.liquid_amount_read);
         snapshot.amounts.insert(chunk.coord, amounts);
+
+        let mut kinds = Box::new([LIQ_NONE; CHUNK_AREA]);
+        kinds.copy_from_slice(&*chunk.liquid_kind);
+        snapshot.kinds.insert(chunk.coord, kinds);
 
         let mut terrain = Box::new([MAT_AIR; CHUNK_AREA]);
         terrain.copy_from_slice(&*chunk.terrain);

--- a/crates/sim-fluid/src/vertical_flow.rs
+++ b/crates/sim-fluid/src/vertical_flow.rs
@@ -1,0 +1,299 @@
+use bevy_ecs::prelude::*;
+use tile_core::activity::WakeRequests;
+use tile_core::chunk::ChunkData;
+use tile_core::coords::{CHUNK_AREA, CHUNK_SIZE, ChunkCoord};
+use tile_core::liquid::{LIQ_NONE, LiquidId};
+use tile_core::material::MAT_AIR;
+
+use crate::LiquidRegistry;
+use crate::snapshot::LiquidSnapshot;
+
+/// Bibel §9.5 — Vertical flow: gravity fall + density-based layering.
+///
+/// "Down" = lower cz. Each tile checks the chunk directly below (cz-1, same x,y).
+///
+/// Cases:
+///   1. Below is air (no liquid): liquid falls — full transfer.
+///   2. Below has lighter liquid: density swap — heavier sinks, lighter rises.
+///   3. Below has same or heavier liquid: stable, no action.
+///
+/// Symmetric pattern: both chunks read from snapshot, write only own buffer.
+pub fn liquid_vertical_flow(
+    mut chunks: Query<&mut ChunkData>,
+    snapshot: Res<LiquidSnapshot>,
+    liquid_reg: Option<Res<LiquidRegistry>>,
+    mut wake: ResMut<WakeRequests>,
+) {
+    for mut chunk in chunks.iter_mut() {
+        let coord = chunk.coord;
+        let has_liquid = chunk.liquid_amount_read.iter().any(|&a| a > 0);
+
+        // Check if chunk above has liquid that could fall into us
+        let above = ChunkCoord {
+            cz: coord.cz + 1,
+            ..coord
+        };
+        let below = ChunkCoord {
+            cz: coord.cz - 1,
+            ..coord
+        };
+        let above_has_liquid = snapshot.chunk_has_liquid(above);
+
+        if !has_liquid && !above_has_liquid {
+            continue;
+        }
+
+        let mut amounts = [0u8; CHUNK_AREA];
+        amounts.copy_from_slice(&*chunk.liquid_amount_read);
+        let mut kind_write: [LiquidId; CHUNK_AREA] = [LIQ_NONE; CHUNK_AREA];
+        kind_write.copy_from_slice(&*chunk.liquid_kind);
+        let mut amount_deltas = [0i16; CHUNK_AREA];
+
+        for y in 0..CHUNK_SIZE {
+            for x in 0..CHUNK_SIZE {
+                let idx = y * CHUNK_SIZE + x;
+
+                if chunk.terrain[idx] != MAT_AIR {
+                    continue;
+                }
+
+                let self_kind = chunk.liquid_kind[idx];
+                let self_amt = amounts[idx];
+
+                // ── Check tile directly below (same x,y, chunk cz-1) ─────────
+                let nb_idx = idx; // same local position in the chunk below
+
+                if snapshot.is_passable(below, nb_idx) {
+                    let nb_kind = snapshot.get_kind(below, nb_idx);
+                    let nb_amt = snapshot.get_amount(below, nb_idx);
+
+                    if self_kind != LIQ_NONE && self_amt > 0 {
+                        if nb_kind == LIQ_NONE || nb_amt == 0 {
+                            // Case 1: air below → gravity fall
+                            amount_deltas[idx] -= self_amt as i16;
+                            kind_write[idx] = LIQ_NONE;
+                            wake.pending.push(below);
+                        } else if nb_kind != self_kind {
+                            // Case 2: different liquid → density swap if self is denser
+                            let self_density = density(&liquid_reg, self_kind);
+                            let nb_density = density(&liquid_reg, nb_kind);
+                            if self_density > nb_density {
+                                // Self (upper) is denser → swap: we become nb's liquid
+                                amount_deltas[idx] = nb_amt as i16 - self_amt as i16;
+                                kind_write[idx] = nb_kind;
+                                wake.pending.push(below);
+                            }
+                        }
+                    }
+                }
+
+                // ── Receive liquid from above (chunk cz+1, same idx) ─────────
+                if snapshot.is_passable(above, nb_idx) {
+                    let above_kind = snapshot.get_kind(above, nb_idx);
+                    let above_amt = snapshot.get_amount(above, nb_idx);
+
+                    if above_kind != LIQ_NONE && above_amt > 0 {
+                        if self_kind == LIQ_NONE || self_amt == 0 {
+                            // Case 1 (receiving side): accept falling liquid
+                            amount_deltas[idx] += above_amt as i16;
+                            kind_write[idx] = above_kind;
+                        } else if above_kind != self_kind {
+                            // Case 2 (receiving side): density swap — we rise if we're lighter
+                            let above_density = density(&liquid_reg, above_kind);
+                            let self_density = density(&liquid_reg, self_kind);
+                            if above_density > self_density {
+                                // Above is denser, we (lighter) should rise → we become above's liquid
+                                amount_deltas[idx] = above_amt as i16 - self_amt as i16;
+                                kind_write[idx] = above_kind;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // ── Apply deltas ──────────────────────────────────────────────────
+        chunk.liquid_amount_write.copy_from_slice(&amounts);
+        for (i, &d) in amount_deltas.iter().enumerate() {
+            if d != 0 {
+                let v = (chunk.liquid_amount_write[i] as i16) + d;
+                chunk.liquid_amount_write[i] = v.clamp(0, 255) as u8;
+            }
+        }
+        chunk.liquid_kind_write.copy_from_slice(&kind_write);
+    }
+}
+
+/// Density for a LiquidId, defaulting to 1.0 if registry missing or id unknown.
+fn density(reg: &Option<Res<LiquidRegistry>>, id: LiquidId) -> f32 {
+    reg.as_ref()
+        .and_then(|r| r.get(id))
+        .map_or(1.0, |p| p.density)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::snapshot::snapshot_liquid;
+    use crate::{LiquidProperties, builtin_liquids};
+    use bevy_app::prelude::*;
+    use bevy_ecs::schedule::IntoSystemConfigs;
+    use tile_core::coords::ChunkCoord;
+
+    fn make_chunk(coord: ChunkCoord) -> ChunkData {
+        ChunkData::new_filled(coord, MAT_AIR)
+    }
+
+    fn make_app() -> App {
+        let mut app = App::new();
+        app.init_resource::<LiquidSnapshot>();
+        app.init_resource::<WakeRequests>();
+        let mut reg = LiquidRegistry::default();
+        for (id, props) in builtin_liquids() {
+            reg.add(id, props);
+        }
+        app.insert_resource(reg);
+        app.add_systems(
+            Update,
+            (
+                snapshot_liquid,
+                liquid_vertical_flow,
+                crate::fluid_ca::swap_buffers_system,
+            )
+                .chain(),
+        );
+        app
+    }
+
+    fn total_liquid(chunk: &ChunkData) -> u32 {
+        chunk.liquid_amount_read.iter().map(|&a| a as u32).sum()
+    }
+
+    #[test]
+    fn test_water_falls_into_air() {
+        let mut app = make_app();
+
+        // Chunk A (cz=1): water at tile (16,16) — above
+        let mut chunk_a = make_chunk(ChunkCoord {
+            cx: 0,
+            cy: 0,
+            cz: 1,
+        });
+        let idx = 16 * CHUNK_SIZE + 16;
+        chunk_a.liquid_kind[idx] = LiquidId(1); // Water
+        chunk_a.liquid_amount_read[idx] = 100;
+
+        // Chunk B (cz=0): all air — below
+        let chunk_b = make_chunk(ChunkCoord {
+            cx: 0,
+            cy: 0,
+            cz: 0,
+        });
+
+        let ea = app.world_mut().spawn(chunk_a).id();
+        let eb = app.world_mut().spawn(chunk_b).id();
+
+        let initial = total_liquid(app.world().get::<ChunkData>(ea).unwrap())
+            + total_liquid(app.world().get::<ChunkData>(eb).unwrap());
+
+        app.update(); // 1 tick
+
+        let a = app.world().get::<ChunkData>(ea).unwrap();
+        let b = app.world().get::<ChunkData>(eb).unwrap();
+
+        assert_eq!(
+            total_liquid(a) + total_liquid(b),
+            initial,
+            "mass conserved during fall"
+        );
+        assert_eq!(a.liquid_amount_read[idx], 0, "water left upper chunk");
+        assert_eq!(
+            b.liquid_amount_read[idx], 100,
+            "water arrived in lower chunk"
+        );
+        assert_eq!(b.liquid_kind[idx], LiquidId(1), "liquid kind preserved");
+    }
+
+    #[test]
+    fn test_oil_water_density_swap() {
+        let mut app = make_app();
+
+        let idx = 16 * CHUNK_SIZE + 16;
+
+        // Chunk A (cz=1, upper): Water (density=1.0) — unstable on top of Oil
+        let mut chunk_a = make_chunk(ChunkCoord {
+            cx: 0,
+            cy: 0,
+            cz: 1,
+        });
+        chunk_a.liquid_kind[idx] = LiquidId(1); // Water
+        chunk_a.liquid_amount_read[idx] = 80;
+
+        // Chunk B (cz=0, lower): Oil (density=0.85) — lighter, should rise
+        let mut chunk_b = make_chunk(ChunkCoord {
+            cx: 0,
+            cy: 0,
+            cz: 0,
+        });
+        chunk_b.liquid_kind[idx] = LiquidId(4); // Oil
+        chunk_b.liquid_amount_read[idx] = 60;
+
+        let ea = app.world_mut().spawn(chunk_a).id();
+        let eb = app.world_mut().spawn(chunk_b).id();
+
+        let initial = total_liquid(app.world().get::<ChunkData>(ea).unwrap())
+            + total_liquid(app.world().get::<ChunkData>(eb).unwrap());
+
+        app.update(); // 1 tick — density swap should occur
+
+        let a = app.world().get::<ChunkData>(ea).unwrap();
+        let b = app.world().get::<ChunkData>(eb).unwrap();
+
+        assert_eq!(total_liquid(a) + total_liquid(b), initial, "mass conserved");
+        // After swap: Oil (lighter) should be on top (cz=1), Water (denser) below (cz=0)
+        assert_eq!(a.liquid_kind[idx], LiquidId(4), "oil rose to upper chunk");
+        assert_eq!(b.liquid_kind[idx], LiquidId(1), "water sank to lower chunk");
+        assert_eq!(a.liquid_amount_read[idx], 60, "oil amount in upper");
+        assert_eq!(b.liquid_amount_read[idx], 80, "water amount in lower");
+    }
+
+    #[test]
+    fn test_stable_layering_no_swap() {
+        let mut app = make_app();
+
+        let idx = 10 * CHUNK_SIZE + 10;
+
+        // Already stable: Oil (light) on top, Water (heavy) below
+        let mut chunk_a = make_chunk(ChunkCoord {
+            cx: 0,
+            cy: 0,
+            cz: 1,
+        });
+        chunk_a.liquid_kind[idx] = LiquidId(4); // Oil — lighter, already on top
+        chunk_a.liquid_amount_read[idx] = 50;
+
+        let mut chunk_b = make_chunk(ChunkCoord {
+            cx: 0,
+            cy: 0,
+            cz: 0,
+        });
+        chunk_b.liquid_kind[idx] = LiquidId(1); // Water — heavier, already below
+        chunk_b.liquid_amount_read[idx] = 50;
+
+        let ea = app.world_mut().spawn(chunk_a).id();
+        let eb = app.world_mut().spawn(chunk_b).id();
+
+        for _ in 0..5 {
+            app.update();
+        }
+
+        let a = app.world().get::<ChunkData>(ea).unwrap();
+        let b = app.world().get::<ChunkData>(eb).unwrap();
+
+        // Should not swap (already stable)
+        assert_eq!(a.liquid_kind[idx], LiquidId(4), "oil stays on top");
+        assert_eq!(b.liquid_kind[idx], LiquidId(1), "water stays below");
+        assert_eq!(a.liquid_amount_read[idx], 50);
+        assert_eq!(b.liquid_amount_read[idx], 50);
+    }
+}


### PR DESCRIPTION
## Summary
- `liquid_kind_write` double-buffer added to `ChunkData`; `swap_buffers()` now includes kind swap (Bibel §8.1)
- `LiquidSnapshot` extended with `kinds` map + `get_kind()` / `chunk_has_liquid()` helpers
- New `liquid_vertical_flow` system handles gravity fall (liquid → air below) and density swap (heavier sinks, lighter rises)
- System order: `snapshot_liquid → fluid_step_local → liquid_vertical_flow → swap_buffers_system`
- Builds on P4.4 (base branch: `feature/p4.4-snapshot`)

## Test plan
- [x] `test_water_falls_into_air`: water at cz=1 falls to cz=0 in one tick, mass conserved, kind preserved
- [x] `test_oil_water_density_swap`: water above oil (unstable) → one tick → oil on top, water below
- [x] `test_stable_layering_no_swap`: oil above water (stable) → 5 ticks → no change
- [x] All 12 sim-fluid tests pass, full workspace green

🤖 Generated with [Claude Code](https://claude.com/claude-code)