### PR TITLE
feat(persistence): P5.1 — SaveHeader, write/read/validate, SaveLayout

### DIFF
--- a/crates/persistence/Cargo.toml
+++ b/crates/persistence/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+bincode = "1.3.3"
+serde = { version = "1", features = ["derive"] }
+thiserror = "1"

--- a/crates/persistence/src/header.rs
+++ b/crates/persistence/src/header.rs
@@ -1,0 +1,132 @@
+use serde::{Deserialize, Serialize};
+use std::io::{Read, Write};
+use thiserror::Error;
+
+pub const SAVE_MAGIC: [u8; 4] = *b"TILE";
+pub const SAVE_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SaveHeader {
+    pub magic: [u8; 4],
+    pub version: u32,
+    pub game_version: String,
+    /// Unix timestamp (seconds since epoch).
+    pub timestamp: u64,
+    pub seed: u64,
+    pub world_size: (i32, i32),
+}
+
+impl SaveHeader {
+    pub fn new(seed: u64, world_size: (i32, i32)) -> Self {
+        Self {
+            magic: SAVE_MAGIC,
+            version: SAVE_VERSION,
+            game_version: env!("CARGO_PKG_VERSION").to_string(),
+            timestamp: current_unix_seconds(),
+            seed,
+            world_size,
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum SaveError {
+    #[error("invalid magic bytes: expected {expected:?}, got {got:?}")]
+    BadMagic { expected: [u8; 4], got: [u8; 4] },
+    #[error("unsupported save version {0}; expected {SAVE_VERSION}")]
+    UnsupportedVersion(u32),
+    #[error("i/o error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("deserialization error: {0}")]
+    Decode(#[from] bincode::Error),
+}
+
+pub fn write_header<W: Write>(writer: &mut W, header: &SaveHeader) -> Result<(), SaveError> {
+    let bytes = bincode::serialize(header)?;
+    writer.write_all(&bytes)?;
+    Ok(())
+}
+
+pub fn read_header<R: Read>(reader: &mut R) -> Result<SaveHeader, SaveError> {
+    let header: SaveHeader = bincode::deserialize_from(reader)?;
+    validate_header(&header)?;
+    Ok(header)
+}
+
+pub fn validate_header(header: &SaveHeader) -> Result<(), SaveError> {
+    if header.magic != SAVE_MAGIC {
+        return Err(SaveError::BadMagic {
+            expected: SAVE_MAGIC,
+            got: header.magic,
+        });
+    }
+    if header.version != SAVE_VERSION {
+        return Err(SaveError::UnsupportedVersion(header.version));
+    }
+    Ok(())
+}
+
+fn current_unix_seconds() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    #[test]
+    fn test_header_roundtrip() {
+        let original = SaveHeader::new(987654321, (128, 128));
+        let mut buf = Vec::new();
+        write_header(&mut buf, &original).expect("write failed");
+
+        let mut cursor = Cursor::new(buf);
+        let loaded = read_header(&mut cursor).expect("read failed");
+
+        assert_eq!(loaded.magic, SAVE_MAGIC);
+        assert_eq!(loaded.version, SAVE_VERSION);
+        assert_eq!(loaded.seed, 987654321);
+        assert_eq!(loaded.world_size, (128, 128));
+    }
+
+    #[test]
+    fn test_bad_magic_rejected() {
+        let mut bad = SaveHeader::new(1, (1, 1));
+        bad.magic = *b"NOPE";
+        let mut buf = Vec::new();
+        // Serialize directly without write_header (skips validation)
+        bincode::serialize_into(&mut buf, &bad).unwrap();
+
+        let mut cursor = Cursor::new(buf);
+        let err = read_header(&mut cursor).expect_err("should fail");
+        assert!(
+            matches!(err, SaveError::BadMagic { .. }),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_wrong_version_rejected() {
+        let mut wrong = SaveHeader::new(1, (1, 1));
+        wrong.version = 99;
+        let mut buf = Vec::new();
+        bincode::serialize_into(&mut buf, &wrong).unwrap();
+
+        let mut cursor = Cursor::new(buf);
+        let err = read_header(&mut cursor).expect_err("should fail");
+        assert!(
+            matches!(err, SaveError::UnsupportedVersion(99)),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_validate_header_directly() {
+        let h = SaveHeader::new(42, (64, 64));
+        assert!(validate_header(&h).is_ok());
+    }
+}

--- a/crates/persistence/src/layout.rs
+++ b/crates/persistence/src/layout.rs
@@ -1,0 +1,103 @@
+use std::path::{Path, PathBuf};
+
+/// Manages the directory layout of a save slot.
+///
+/// ```text
+/// <root>/
+/// ├── header.bin
+/// ├── world.bin
+/// ├── worldgen/
+/// ├── chunks/
+/// ├── entities.bin
+/// └── reactions/
+/// ```
+pub struct SaveLayout {
+    root: PathBuf,
+}
+
+impl SaveLayout {
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        Self { root: root.into() }
+    }
+
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    pub fn header_path(&self) -> PathBuf {
+        self.root.join("header.bin")
+    }
+
+    pub fn world_path(&self) -> PathBuf {
+        self.root.join("world.bin")
+    }
+
+    pub fn entities_path(&self) -> PathBuf {
+        self.root.join("entities.bin")
+    }
+
+    pub fn chunks_dir(&self) -> PathBuf {
+        self.root.join("chunks")
+    }
+
+    pub fn chunk_path(&self, cx: i32, cy: i32, cz: i32) -> PathBuf {
+        self.chunks_dir().join(format!("{cx}_{cy}_{cz}.bin"))
+    }
+
+    pub fn worldgen_dir(&self) -> PathBuf {
+        self.root.join("worldgen")
+    }
+
+    pub fn reactions_dir(&self) -> PathBuf {
+        self.root.join("reactions")
+    }
+
+    /// Create all required subdirectories.
+    pub fn create_dirs(&self) -> std::io::Result<()> {
+        std::fs::create_dir_all(&self.root)?;
+        std::fs::create_dir_all(self.chunks_dir())?;
+        std::fs::create_dir_all(self.worldgen_dir())?;
+        std::fs::create_dir_all(self.reactions_dir())?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn test_create_dirs() {
+        let tmp = std::env::temp_dir().join(format!(
+            "tile_engine_test_{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .subsec_nanos()
+        ));
+        let layout = SaveLayout::new(&tmp);
+        layout.create_dirs().expect("create_dirs failed");
+
+        assert!(layout.chunks_dir().is_dir());
+        assert!(layout.worldgen_dir().is_dir());
+        assert!(layout.reactions_dir().is_dir());
+
+        fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn test_chunk_path_format() {
+        let layout = SaveLayout::new("/save");
+        assert_eq!(
+            layout.chunk_path(3, -2, 1),
+            PathBuf::from("/save/chunks/3_-2_1.bin")
+        );
+    }
+
+    #[test]
+    fn test_header_path() {
+        let layout = SaveLayout::new("/save");
+        assert_eq!(layout.header_path(), PathBuf::from("/save/header.bin"));
+    }
+}

--- a/crates/persistence/src/lib.rs
+++ b/crates/persistence/src/lib.rs
@@ -1,1 +1,5 @@
-// persistence: save/load system
+pub mod header;
+pub mod layout;
+
+pub use header::{SaveError, SaveHeader, read_header, validate_header, write_header};
+pub use layout::SaveLayout;


### PR DESCRIPTION
## Summary

- `SaveHeader` struct with `SAVE_MAGIC = b"TILE"` and `SAVE_VERSION = 1` (Bibel §11.6)
- `write_header` / `read_header` via bincode; `SaveError` with `thiserror`
- `validate_header`: rejects corrupt magic bytes and unsupported versions with clear errors
- `SaveLayout`: typed `PathBuf` accessors for all save-directory entries (`header.bin`, `world.bin`, `chunks/`, `worldgen/`, `reactions/`) + `create_dirs()`

## Test plan

- [x] Header roundtrip (write → read → assert fields match)
- [x] Bad magic bytes rejected with `SaveError::BadMagic`
- [x] Wrong version rejected with `SaveError::UnsupportedVersion`
- [x] `validate_header` accepts valid header directly
- [x] `create_dirs` creates all subdirectories
- [x] `chunk_path` format: `cx_cy_cz.bin`
- [x] `header_path` returns correct path

🤖 Generated with [Claude Code](https://claude.com/claude-code)