### PR TITLE
feat(persistence): P5.3 — entity persistence for LiquidSource/LiquidDrain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,6 +181,7 @@ name = "app"
 version = "0.1.0"
 dependencies = [
  "bevy",
+ "persistence",
  "puffin 0.19.1",
  "puffin_http",
  "render_bevy",
@@ -3486,6 +3487,14 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 [[package]]
 name = "persistence"
 version = "0.1.0"
+dependencies = [
+ "bevy_app",
+ "bevy_ecs",
+ "bincode",
+ "serde",
+ "thiserror 1.0.69",
+ "tile_core",
+]
 
 [[package]]
 name = "petgraph"
@@ -4147,6 +4156,7 @@ dependencies = [
  "bevy_ecs",
  "bincode",
  "bitflags 2.11.1",
+ "persistence",
  "serde",
  "smallvec",
  "tile_core",

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -13,6 +13,7 @@ sim_fluid = { path = "../sim-fluid" }
 worldgen_api = { path = "../worldgen-api" }
 worldgen_earthlike = { path = "../worldgen-earthlike" }
 worldgen_demo = { path = "../worldgen-demo" }
+persistence = { path = "../persistence" }
 
 [features]
 profile = ["dep:puffin", "dep:puffin_http"]

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -1,5 +1,8 @@
 use bevy::prelude::*;
-use sim_fluid::{FluidPlugin, LiquidRegistry, LiquidSource, builtin_liquids};
+use persistence::{
+    LoadRequest, SaveLayout, SaveRequest, SerializedEntity, load_entities, save_entities,
+};
+use sim_fluid::{FluidPlugin, LiquidDrain, LiquidRegistry, LiquidSource, builtin_liquids};
 use tile_core::chunk::ChunkData;
 use tile_core::liquid::LiquidId;
 use tile_core::material::MAT_AIR;
@@ -29,6 +32,8 @@ fn main() {
     app.add_plugins(FluidPlugin);
     app.add_plugins(render_bevy::RenderPlugin);
     app.add_plugins(worldgen_demo::DemoWorldgenPlugin);
+    app.add_plugins(persistence::PersistencePlugin);
+    app.add_systems(Update, (save_entities_system, load_entities_system));
 
     app.init_resource::<tile_core::world::World>();
 
@@ -93,6 +98,66 @@ fn clear_source_terrain(sources: Query<&LiquidSource>, mut chunks: Query<&mut Ch
         let idx = lp.index();
         if let Some(mut chunk) = chunks.iter_mut().find(|c| c.coord == coord) {
             chunk.terrain[idx] = MAT_AIR;
+        }
+    }
+}
+
+fn save_entities_system(
+    mut events: EventReader<SaveRequest>,
+    sources: Query<&LiquidSource>,
+    drains: Query<&LiquidDrain>,
+) {
+    for req in events.read() {
+        let layout = SaveLayout::new(&req.slot);
+        let mut entities: Vec<SerializedEntity> = Vec::new();
+        for source in sources.iter() {
+            let mut e = SerializedEntity::new();
+            if let Err(err) = e.push(source) {
+                eprintln!("[app] failed to serialize LiquidSource: {err}");
+                continue;
+            }
+            entities.push(e);
+        }
+        for drain in drains.iter() {
+            let mut e = SerializedEntity::new();
+            if let Err(err) = e.push(drain) {
+                eprintln!("[app] failed to serialize LiquidDrain: {err}");
+                continue;
+            }
+            entities.push(e);
+        }
+        if let Err(err) = save_entities(&layout, &entities) {
+            eprintln!("[app] entity save failed: {err}");
+        }
+    }
+}
+
+fn load_entities_system(
+    mut events: EventReader<LoadRequest>,
+    mut commands: Commands,
+    existing_sources: Query<Entity, With<LiquidSource>>,
+    existing_drains: Query<Entity, With<LiquidDrain>>,
+) {
+    for req in events.read() {
+        let layout = SaveLayout::new(&req.slot);
+        match load_entities(&layout) {
+            Err(err) => eprintln!("[app] entity load failed: {err}"),
+            Ok(serialized) => {
+                for entity in existing_sources.iter() {
+                    commands.entity(entity).despawn();
+                }
+                for entity in existing_drains.iter() {
+                    commands.entity(entity).despawn();
+                }
+                for se in &serialized {
+                    if let Some(source) = se.get::<LiquidSource>() {
+                        commands.spawn(source);
+                    } else if let Some(drain) = se.get::<LiquidDrain>() {
+                        commands.spawn(drain);
+                    }
+                }
+                eprintln!("[app] loaded {} entities", serialized.len());
+            }
         }
     }
 }

--- a/crates/core/src/chunk.rs
+++ b/crates/core/src/chunk.rs
@@ -102,7 +102,7 @@ mod box_array_liquid {
 
 /// The data for a single chunk of tiles (32×32 = 1024 tiles).
 /// Uses SoA layout with double-buffered fields for simulation.
-#[derive(Component, Serialize, Deserialize)]
+#[derive(Component, Clone, Serialize, Deserialize)]
 pub struct ChunkData {
     pub coord: ChunkCoord,
 

--- a/crates/persistence/Cargo.toml
+++ b/crates/persistence/Cargo.toml
@@ -7,3 +7,6 @@ edition = "2024"
 bincode = "1.3.3"
 serde = { version = "1", features = ["derive"] }
 thiserror = "1"
+tile_core = { path = "../core" }
+bevy_ecs = "0.14.2"
+bevy_app = "0.14.2"

--- a/crates/persistence/src/entities.rs
+++ b/crates/persistence/src/entities.rs
@@ -1,0 +1,183 @@
+use bevy_ecs::prelude::*;
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::io::{BufReader, BufWriter};
+
+use crate::header::SaveError;
+use crate::layout::SaveLayout;
+
+/// Marks a Bevy Component as serializable for entity persistence (Bibel §11.8).
+///
+/// Each concrete type gets a stable numeric TYPE_ID. Must not change between
+/// versions; add a migration if the schema changes.
+pub trait Persistent: Component + Serialize + DeserializeOwned {
+    const TYPE_ID: u32;
+
+    fn serialize_component(&self) -> Result<Vec<u8>, bincode::Error> {
+        bincode::serialize(self)
+    }
+}
+
+/// Wire format for one entity: a list of (TYPE_ID, serialized bytes) pairs.
+/// Renderer components (Sprite, Transform) are never included.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct SerializedEntity {
+    pub components: Vec<(u32, Vec<u8>)>,
+}
+
+impl SerializedEntity {
+    pub fn new() -> Self {
+        Self { components: vec![] }
+    }
+
+    pub fn push<P: Persistent>(&mut self, component: &P) -> Result<(), bincode::Error> {
+        let bytes = component.serialize_component()?;
+        self.components.push((P::TYPE_ID, bytes));
+        Ok(())
+    }
+
+    /// Decode the component with the given TYPE_ID if present.
+    pub fn get<P: Persistent>(&self) -> Option<P> {
+        self.components
+            .iter()
+            .find(|(id, _)| *id == P::TYPE_ID)
+            .and_then(|(_, bytes)| bincode::deserialize(bytes).ok())
+    }
+}
+
+impl Default for SerializedEntity {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Write entity list to `entities.bin`.
+pub fn save_entities(layout: &SaveLayout, entities: &[SerializedEntity]) -> Result<(), SaveError> {
+    let f = fs::File::create(layout.entities_path())?;
+    bincode::serialize_into(BufWriter::new(f), entities)?;
+    Ok(())
+}
+
+/// Read entity list from `entities.bin`. Returns empty vec if file absent.
+pub fn load_entities(layout: &SaveLayout) -> Result<Vec<SerializedEntity>, SaveError> {
+    let path = layout.entities_path();
+    if !path.exists() {
+        return Ok(vec![]);
+    }
+    let f = fs::File::open(path)?;
+    let entities = bincode::deserialize_from(BufReader::new(f))?;
+    Ok(entities)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+
+    // Stub component for tests — doesn't need bevy Component macro in unit tests.
+    #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Component)]
+    struct MockSource {
+        rate: u8,
+        kind: u32,
+    }
+
+    #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Component)]
+    struct MockDrain {
+        rate: u8,
+    }
+
+    impl Persistent for MockSource {
+        const TYPE_ID: u32 = 101;
+    }
+
+    impl Persistent for MockDrain {
+        const TYPE_ID: u32 = 102;
+    }
+
+    fn tmp_dir(id: &str) -> String {
+        std::env::temp_dir()
+            .join(format!("tile_p53_{}_{id}", std::process::id()))
+            .to_string_lossy()
+            .into_owned()
+    }
+
+    #[test]
+    fn test_serialize_entity_roundtrip() {
+        let src = MockSource { rate: 5, kind: 1 };
+        let mut e = SerializedEntity::new();
+        e.push(&src).unwrap();
+        let recovered: MockSource = e.get().unwrap();
+        assert_eq!(recovered, src);
+    }
+
+    #[test]
+    fn test_wrong_type_id_returns_none() {
+        let drain = MockDrain { rate: 3 };
+        let mut e = SerializedEntity::new();
+        e.push(&drain).unwrap();
+        let recovered: Option<MockSource> = e.get();
+        assert!(recovered.is_none());
+    }
+
+    #[test]
+    fn test_save_load_entities() {
+        let slot = tmp_dir("save_load");
+        let layout = SaveLayout::new(&slot);
+        layout.create_dirs().unwrap();
+
+        let src = MockSource { rate: 7, kind: 2 };
+        let drain = MockDrain { rate: 4 };
+
+        let mut e1 = SerializedEntity::new();
+        e1.push(&src).unwrap();
+
+        let mut e2 = SerializedEntity::new();
+        e2.push(&drain).unwrap();
+
+        save_entities(&layout, &[e1, e2]).unwrap();
+        let loaded = load_entities(&layout).unwrap();
+
+        assert_eq!(loaded.len(), 2);
+        assert_eq!(loaded[0].get::<MockSource>().unwrap(), src);
+        assert_eq!(loaded[1].get::<MockDrain>().unwrap(), drain);
+
+        std::fs::remove_dir_all(&slot).ok();
+    }
+
+    #[test]
+    fn test_load_entities_missing_file_returns_empty() {
+        let slot = tmp_dir("missing");
+        let layout = SaveLayout::new(&slot);
+        layout.create_dirs().unwrap();
+
+        let result = load_entities(&layout).unwrap();
+        assert!(result.is_empty());
+
+        std::fs::remove_dir_all(&slot).ok();
+    }
+
+    #[test]
+    fn test_no_sprite_data_in_save() {
+        // Verify that only registered Persistent components end up in the file.
+        // Sprite/Transform are not Persistent → can't be added → file has no sprite data.
+        let slot = tmp_dir("no_sprite");
+        let layout = SaveLayout::new(&slot);
+        layout.create_dirs().unwrap();
+
+        let src = MockSource { rate: 1, kind: 0 };
+        let mut e = SerializedEntity::new();
+        e.push(&src).unwrap();
+        save_entities(&layout, &[e]).unwrap();
+
+        let bytes = std::fs::read(layout.entities_path()).unwrap();
+        // "Sprite" as bytes must not appear in the file.
+        let sprite_bytes = b"Sprite";
+        assert!(
+            !bytes.windows(sprite_bytes.len()).any(|w| w == sprite_bytes),
+            "entities.bin must not contain Sprite data"
+        );
+
+        std::fs::remove_dir_all(&slot).ok();
+    }
+}

--- a/crates/persistence/src/lib.rs
+++ b/crates/persistence/src/lib.rs
@@ -1,5 +1,7 @@
 pub mod header;
 pub mod layout;
+pub mod save;
 
 pub use header::{SaveError, SaveHeader, read_header, validate_header, write_header};
 pub use layout::SaveLayout;
+pub use save::{LoadRequest, PersistencePlugin, SaveRequest, load_world, save_world};

--- a/crates/persistence/src/lib.rs
+++ b/crates/persistence/src/lib.rs
@@ -1,7 +1,9 @@
+pub mod entities;
 pub mod header;
 pub mod layout;
 pub mod save;
 
+pub use entities::{Persistent, SerializedEntity, load_entities, save_entities};
 pub use header::{SaveError, SaveHeader, read_header, validate_header, write_header};
 pub use layout::SaveLayout;
 pub use save::{LoadRequest, PersistencePlugin, SaveRequest, load_world, save_world};

--- a/crates/persistence/src/save.rs
+++ b/crates/persistence/src/save.rs
@@ -166,10 +166,10 @@ fn handle_load_requests(
                 world.current_tick = world_save.current_tick;
                 for loaded in loaded_chunks {
                     let coord = loaded.coord;
-                    if let Some(&entity) = world.chunks.get(&coord) {
-                        if let Ok(mut chunk) = chunks.get_mut(entity) {
-                            *chunk = loaded;
-                        }
+                    if let Some(&entity) = world.chunks.get(&coord)
+                        && let Ok(mut chunk) = chunks.get_mut(entity)
+                    {
+                        *chunk = loaded;
                     }
                 }
                 eprintln!("[persistence] loaded from {}", req.slot);

--- a/crates/persistence/src/save.rs
+++ b/crates/persistence/src/save.rs
@@ -1,0 +1,395 @@
+use bevy_ecs::prelude::*;
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::io::{BufReader, BufWriter};
+use tile_core::chunk::ChunkData;
+use tile_core::world::World;
+
+use crate::header::{SaveError, SaveHeader, read_header, write_header};
+use crate::layout::SaveLayout;
+
+// ── Events ────────────────────────────────────────────────────────────────────
+
+#[derive(Event, Debug, Clone)]
+pub struct SaveRequest {
+    pub slot: String,
+}
+
+#[derive(Event, Debug, Clone)]
+pub struct LoadRequest {
+    pub slot: String,
+}
+
+// ── On-disk World state (Entity not serializable) ─────────────────────────────
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct WorldSave {
+    pub current_tick: u64,
+}
+
+// ── Pure save/load functions ─────────────────────────────────────────────────
+
+/// Write header + world state + all dirty chunks to `layout`.
+///
+/// Atomic: writes to `<root>.tmp/` first, then renames to `<root>`.
+pub fn save_world(
+    layout: &SaveLayout,
+    header: &SaveHeader,
+    world: &World,
+    chunks: impl Iterator<Item = ChunkData>,
+) -> Result<(), SaveError> {
+    // Write to a tmp directory alongside the real one.
+    let tmp_root = {
+        let mut p = layout.root().to_path_buf();
+        let name = p
+            .file_name()
+            .map(|n| format!("{}.tmp", n.to_string_lossy()))
+            .unwrap_or_else(|| "save.tmp".to_string());
+        p.set_file_name(name);
+        p
+    };
+    let tmp_layout = SaveLayout::new(&tmp_root);
+    tmp_layout.create_dirs()?;
+
+    // header.bin
+    {
+        let f = fs::File::create(tmp_layout.header_path())?;
+        write_header(&mut BufWriter::new(f), header)?;
+    }
+
+    // world.bin — current_tick only (chunk-map rebuilt from chunk files + worldgen on load)
+    {
+        let world_save = WorldSave {
+            current_tick: world.current_tick,
+        };
+        let f = fs::File::create(tmp_layout.world_path())?;
+        bincode::serialize_into(BufWriter::new(f), &world_save)?;
+    }
+
+    // chunks/<cx>_<cy>_<cz>.bin — dirty chunks only
+    for chunk in chunks {
+        if !chunk.dirty {
+            continue;
+        }
+        let c = chunk.coord;
+        let path = tmp_layout.chunk_path(c.cx, c.cy, c.cz);
+        let f = fs::File::create(path)?;
+        bincode::serialize_into(BufWriter::new(f), &chunk)?;
+    }
+
+    // Atomic rename: remove old (if exists), rename tmp → real.
+    if layout.root().exists() {
+        fs::remove_dir_all(layout.root())?;
+    }
+    fs::rename(&tmp_root, layout.root())?;
+
+    Ok(())
+}
+
+/// Load a save from `layout`.
+///
+/// Restores `world.current_tick` and returns all saved dirty chunks.
+/// The caller is responsible for applying them to existing ECS entities.
+pub fn load_world(layout: &SaveLayout) -> Result<(WorldSave, Vec<ChunkData>), SaveError> {
+    // Validate header.
+    {
+        let f = fs::File::open(layout.header_path())?;
+        read_header(&mut BufReader::new(f))?;
+    }
+
+    // World state.
+    let world_save: WorldSave = {
+        let f = fs::File::open(layout.world_path())?;
+        bincode::deserialize_from(BufReader::new(f))?
+    };
+
+    // Dirty chunks.
+    let chunks_dir = layout.chunks_dir();
+    let mut chunks = Vec::new();
+    if chunks_dir.is_dir() {
+        for entry in fs::read_dir(&chunks_dir)? {
+            let path = entry?.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("bin") {
+                continue;
+            }
+            let f = fs::File::open(&path)?;
+            let mut chunk: ChunkData = bincode::deserialize_from(BufReader::new(f))?;
+            chunk.dirty = true; // restored from save — still player-modified
+            chunks.push(chunk);
+        }
+    }
+
+    Ok((world_save, chunks))
+}
+
+// ── Bevy Plugin ───────────────────────────────────────────────────────────────
+
+pub struct PersistencePlugin;
+
+impl bevy_app::Plugin for PersistencePlugin {
+    fn build(&self, app: &mut bevy_app::App) {
+        app.add_event::<SaveRequest>();
+        app.add_event::<LoadRequest>();
+        app.add_systems(
+            bevy_app::Update,
+            (handle_save_requests, handle_load_requests).chain(),
+        );
+    }
+}
+
+fn handle_save_requests(
+    mut events: EventReader<SaveRequest>,
+    world: Res<World>,
+    chunks: Query<&ChunkData>,
+) {
+    for req in events.read() {
+        let layout = SaveLayout::new(&req.slot);
+        let header = SaveHeader::new(0, (0, 0)); // seed/size not available here; P5.3 will wire WorldgenConfig
+        if let Err(e) = save_world(&layout, &header, &world, chunks.iter().cloned()) {
+            eprintln!("[persistence] save failed: {e}");
+        } else {
+            eprintln!("[persistence] saved to {}", req.slot);
+        }
+    }
+}
+
+fn handle_load_requests(
+    mut events: EventReader<LoadRequest>,
+    mut world: ResMut<World>,
+    mut chunks: Query<&mut ChunkData>,
+) {
+    for req in events.read() {
+        let layout = SaveLayout::new(&req.slot);
+        match load_world(&layout) {
+            Err(e) => eprintln!("[persistence] load failed: {e}"),
+            Ok((world_save, loaded_chunks)) => {
+                world.current_tick = world_save.current_tick;
+                for loaded in loaded_chunks {
+                    let coord = loaded.coord;
+                    if let Some(&entity) = world.chunks.get(&coord) {
+                        if let Ok(mut chunk) = chunks.get_mut(entity) {
+                            *chunk = loaded;
+                        }
+                    }
+                }
+                eprintln!("[persistence] loaded from {}", req.slot);
+            }
+        }
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tile_core::coords::ChunkCoord;
+    use tile_core::material::{MAT_AIR, MaterialId};
+
+    fn tmp_slot(id: &str) -> String {
+        std::env::temp_dir()
+            .join(format!("tile_engine_p52_{}_{id}", std::process::id()))
+            .to_string_lossy()
+            .into_owned()
+    }
+
+    fn make_dirty_chunk(coord: ChunkCoord, mat: MaterialId) -> ChunkData {
+        let mut c = ChunkData::new_filled(coord, MAT_AIR);
+        c.terrain[0] = mat;
+        c.dirty = true;
+        c
+    }
+
+    fn make_clean_chunk(coord: ChunkCoord) -> ChunkData {
+        ChunkData::new_filled(coord, MAT_AIR)
+    }
+
+    fn make_world_with_chunks(chunks: &[(ChunkCoord, Entity)]) -> World {
+        let mut w = World::default();
+        w.current_tick = 42;
+        for (coord, entity) in chunks {
+            w.chunks.insert(*coord, *entity);
+        }
+        w
+    }
+
+    #[test]
+    fn test_save_load_roundtrip() {
+        let slot = tmp_slot("roundtrip");
+        let layout = SaveLayout::new(&slot);
+
+        let coord_a = ChunkCoord {
+            cx: 1,
+            cy: 2,
+            cz: 0,
+        };
+        let coord_b = ChunkCoord {
+            cx: 3,
+            cy: 4,
+            cz: 0,
+        };
+
+        let dirty = make_dirty_chunk(coord_a, MaterialId(1));
+        let clean = make_clean_chunk(coord_b);
+
+        let world = make_world_with_chunks(&[
+            (coord_a, Entity::from_raw(10)),
+            (coord_b, Entity::from_raw(11)),
+        ]);
+
+        let header = SaveHeader::new(999, (64, 64));
+        save_world(&layout, &header, &world, [dirty.clone(), clean].into_iter())
+            .expect("save failed");
+
+        let (ws, loaded_chunks) = load_world(&layout).expect("load failed");
+
+        assert_eq!(ws.current_tick, 42);
+        // Only dirty chunk should be on disk.
+        assert_eq!(loaded_chunks.len(), 1);
+        assert_eq!(loaded_chunks[0].coord, coord_a);
+        assert_eq!(loaded_chunks[0].terrain[0], MaterialId(1));
+
+        std::fs::remove_dir_all(&slot).ok();
+    }
+
+    #[test]
+    fn test_clean_chunks_not_saved() {
+        let slot = tmp_slot("clean");
+        let layout = SaveLayout::new(&slot);
+
+        let coord = ChunkCoord {
+            cx: 0,
+            cy: 0,
+            cz: 0,
+        };
+        let clean = make_clean_chunk(coord);
+        let world = make_world_with_chunks(&[(coord, Entity::from_raw(1))]);
+
+        let header = SaveHeader::new(0, (0, 0));
+        save_world(&layout, &header, &world, [clean].into_iter()).expect("save failed");
+
+        let (_, chunks) = load_world(&layout).expect("load failed");
+        assert!(chunks.is_empty(), "no dirty chunks → nothing saved");
+
+        std::fs::remove_dir_all(&slot).ok();
+    }
+
+    #[test]
+    fn test_bitidentical_roundtrip() {
+        let slot_a = tmp_slot("bit_a");
+        let slot_b = tmp_slot("bit_b");
+
+        let coord = ChunkCoord {
+            cx: 0,
+            cy: 0,
+            cz: 0,
+        };
+        let dirty = make_dirty_chunk(coord, MaterialId(3));
+        let mut world = make_world_with_chunks(&[(coord, Entity::from_raw(1))]);
+        world.current_tick = 77;
+
+        let header = SaveHeader::new(123, (32, 32));
+
+        // First save.
+        save_world(
+            &SaveLayout::new(&slot_a),
+            &header,
+            &world,
+            [dirty.clone()].into_iter(),
+        )
+        .expect("save_a failed");
+
+        // Load, then save again.
+        let (ws, loaded) = load_world(&SaveLayout::new(&slot_a)).expect("load failed");
+        world.current_tick = ws.current_tick;
+        let reloaded_chunk = loaded.into_iter().next().unwrap();
+
+        save_world(
+            &SaveLayout::new(&slot_b),
+            &header,
+            &world,
+            [reloaded_chunk].into_iter(),
+        )
+        .expect("save_b failed");
+
+        // Compare chunk files — must be bitidentical.
+        let file_a = SaveLayout::new(&slot_a).chunk_path(coord.cx, coord.cy, coord.cz);
+        let file_b = SaveLayout::new(&slot_b).chunk_path(coord.cx, coord.cy, coord.cz);
+        let bytes_a = std::fs::read(&file_a).unwrap();
+        let bytes_b = std::fs::read(&file_b).unwrap();
+        assert_eq!(
+            bytes_a, bytes_b,
+            "save→load→save must produce bitidentical chunk files"
+        );
+
+        std::fs::remove_dir_all(&slot_a).ok();
+        std::fs::remove_dir_all(&slot_b).ok();
+    }
+
+    #[test]
+    fn test_atomic_write_no_corruption_on_clean_target() {
+        let slot = tmp_slot("atomic");
+        let layout = SaveLayout::new(&slot);
+
+        let coord = ChunkCoord {
+            cx: 0,
+            cy: 0,
+            cz: 0,
+        };
+        let dirty = make_dirty_chunk(coord, MaterialId(2));
+        let world = make_world_with_chunks(&[(coord, Entity::from_raw(1))]);
+        let header = SaveHeader::new(0, (0, 0));
+
+        // First save creates the directory.
+        save_world(&layout, &header, &world, [dirty].into_iter()).expect("first save failed");
+        assert!(layout.root().is_dir(), "save dir must exist after save");
+        assert!(
+            !layout
+                .root()
+                .with_file_name(format!(
+                    "{}.tmp",
+                    layout.root().file_name().unwrap().to_string_lossy()
+                ))
+                .exists(),
+            "tmp dir must be cleaned up"
+        );
+
+        std::fs::remove_dir_all(&slot).ok();
+    }
+
+    #[test]
+    fn test_bad_magic_rejected_on_load() {
+        use crate::header::SAVE_MAGIC;
+        use std::io::Write;
+
+        let slot = tmp_slot("badmagic");
+        let layout = SaveLayout::new(&slot);
+        layout.create_dirs().unwrap();
+
+        // Write a header with wrong magic bytes directly.
+        let mut f = std::fs::File::create(layout.header_path()).unwrap();
+        let bad: [u8; 4] = *b"XXXX";
+        let version: u32 = 1;
+        // Serialize manually (magic, version, then enough bytes).
+        let _ = SAVE_MAGIC; // silence unused
+        f.write_all(&bad).unwrap();
+        f.write_all(&version.to_le_bytes()).unwrap();
+        // Write placeholder bytes so bincode has enough data.
+        f.write_all(&[0u8; 64]).unwrap();
+        drop(f);
+
+        let result = load_world(&layout);
+        assert!(result.is_err(), "should reject bad magic");
+        let err = result.err().unwrap();
+        // Either BadMagic or Decode error (bincode sees corrupt header).
+        assert!(
+            matches!(
+                err,
+                crate::header::SaveError::BadMagic { .. } | crate::header::SaveError::Decode(_)
+            ),
+            "unexpected error variant"
+        );
+
+        std::fs::remove_dir_all(&slot).ok();
+    }
+}

--- a/crates/sim-fluid/Cargo.toml
+++ b/crates/sim-fluid/Cargo.toml
@@ -10,6 +10,7 @@ bitflags = { version = "2.6.0", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 smallvec = "1"
 tile_core = { path = "../core" }
+persistence = { path = "../persistence" }
 
 [dev-dependencies]
 bincode = "1.3.3"

--- a/crates/sim-fluid/src/source_drain.rs
+++ b/crates/sim-fluid/src/source_drain.rs
@@ -26,6 +26,10 @@ pub enum LiquidFilter {
     ByFlags(LiquidFlags),
 }
 
+impl persistence::Persistent for LiquidSource {
+    const TYPE_ID: u32 = 1;
+}
+
 /// Bibel §9.8 — removes liquid from a tile each tick (rate units, floor 0).
 #[derive(Component, Debug, Clone, Serialize, Deserialize)]
 pub struct LiquidDrain {
@@ -33,6 +37,10 @@ pub struct LiquidDrain {
     /// Units removed per tick.
     pub rate: u8,
     pub accepts: LiquidFilter,
+}
+
+impl persistence::Persistent for LiquidDrain {
+    const TYPE_ID: u32 = 2;
 }
 
 /// PreTick system — runs before `snapshot_liquid`.


### PR DESCRIPTION
## Summary

- `Persistent` trait (`TYPE_ID: u32 + Serialize/Deserialize`) + `SerializedEntity` in `persistence` crate — type-safe component serialization with numeric type IDs
- `save_entities`/`load_entities` write/read `entities.bin` in the save slot
- `impl Persistent for LiquidSource { TYPE_ID = 1 }` and `LiquidDrain { TYPE_ID = 2 }` in `sim_fluid`
- `save_entities_system` / `load_entities_system` in `app` respond to `SaveRequest`/`LoadRequest` events; on load, despawns existing entities before spawning restored ones

## Test plan

- [x] `persistence::entities` — 5 unit tests: roundtrip, wrong TYPE_ID returns None, save/load file roundtrip, missing file returns empty, no Sprite data in save
- [x] All workspace tests pass (58 total)
- [x] `cargo clippy --workspace` — clean
- [x] `cargo build --workspace` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)