### PR TITLE
perf: eliminate 512 alloc/tick in snapshot + O(1) chunk lookup

### DIFF
--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -8,6 +8,7 @@ use sim_reaction::{Condition, Effect, Reaction, ReactionRegistry, Trigger};
 use tile_core::chunk::ChunkData;
 use tile_core::liquid::{LIQ_NONE, LiquidId};
 use tile_core::material::{MAT_AIR, MaterialId};
+use tile_core::world::World;
 
 fn main() {
     let mut app = App::new();
@@ -102,11 +103,18 @@ fn spawn_liquid_sources(mut commands: Commands) {
 }
 
 /// Force-clear terrain at every LiquidSource position so sources are never blocked by worldgen.
-fn clear_source_terrain(sources: Query<&LiquidSource>, mut chunks: Query<&mut ChunkData>) {
+fn clear_source_terrain(
+    sources: Query<&LiquidSource>,
+    world_res: Res<World>,
+    mut chunks: Query<&mut ChunkData>,
+) {
     for source in sources.iter() {
         let (coord, lp) = source.pos.split();
         let idx = lp.index();
-        if let Some(mut chunk) = chunks.iter_mut().find(|c| c.coord == coord) {
+        let Some(&entity) = world_res.chunks.get(&coord) else {
+            continue;
+        };
+        if let Ok(mut chunk) = chunks.get_mut(entity) {
             chunk.terrain[idx] = MAT_AIR;
         }
     }

--- a/crates/sim-fluid/src/fluid_ca.rs
+++ b/crates/sim-fluid/src/fluid_ca.rs
@@ -63,6 +63,12 @@ pub fn flow_with_pressure(
 pub fn pressure_propagation(mut chunks: Query<&mut ChunkData>, snapshot: Res<LiquidSnapshot>) {
     for mut chunk in chunks.iter_mut() {
         let coord = chunk.coord;
+        let has_liquid = chunk.liquid_amount_read.iter().any(|&a| a > 0);
+        if !has_liquid && !snapshot.has_any_neighbor_with_liquid(coord) {
+            chunk.pressure_write.fill(0);
+            continue;
+        }
+
         for i in 0..CHUNK_AREA {
             if chunk.terrain[i] != MAT_AIR || chunk.liquid_amount_read[i] == 0 {
                 chunk.pressure_write[i] = 0;

--- a/crates/sim-fluid/src/snapshot.rs
+++ b/crates/sim-fluid/src/snapshot.rs
@@ -67,6 +67,30 @@ impl LiquidSnapshot {
         .any(|nb| self.amounts.contains_key(nb))
     }
 
+    /// True if any of the 4 horizontal neighbor chunks have non-zero liquid.
+    pub fn has_any_neighbor_with_liquid(&self, coord: ChunkCoord) -> bool {
+        [
+            ChunkCoord {
+                cx: coord.cx + 1,
+                ..coord
+            },
+            ChunkCoord {
+                cx: coord.cx - 1,
+                ..coord
+            },
+            ChunkCoord {
+                cy: coord.cy + 1,
+                ..coord
+            },
+            ChunkCoord {
+                cy: coord.cy - 1,
+                ..coord
+            },
+        ]
+        .iter()
+        .any(|nb| self.chunk_has_liquid(*nb))
+    }
+
     /// True if chunk above (cz+1) or below (cz-1) exists in the snapshot.
     pub fn has_vertical_neighbor(&self, coord: ChunkCoord) -> bool {
         let above = ChunkCoord {
@@ -82,26 +106,43 @@ impl LiquidSnapshot {
 }
 
 /// PreTick system: freeze liquid_amount_read, liquid_kind, and terrain from every chunk.
+///
+/// Uses entry-based insertion to reuse existing heap allocations across ticks,
+/// avoiding ~4 Box alloc/dealloc per chunk per tick.
 pub fn snapshot_liquid(mut snapshot: ResMut<LiquidSnapshot>, chunks: Query<&ChunkData>) {
-    snapshot.amounts.clear();
-    snapshot.kinds.clear();
-    snapshot.terrain.clear();
-    snapshot.pressures.clear();
+    let mut seen = std::collections::HashSet::with_capacity(chunks.iter().len());
+
     for chunk in chunks.iter() {
-        let mut amounts = Box::new([0u8; CHUNK_AREA]);
-        amounts.copy_from_slice(&*chunk.liquid_amount_read);
-        snapshot.amounts.insert(chunk.coord, amounts);
+        seen.insert(chunk.coord);
 
-        let mut kinds = Box::new([LIQ_NONE; CHUNK_AREA]);
-        kinds.copy_from_slice(&*chunk.liquid_kind);
-        snapshot.kinds.insert(chunk.coord, kinds);
+        snapshot
+            .amounts
+            .entry(chunk.coord)
+            .or_insert_with(|| Box::new([0u8; CHUNK_AREA]))
+            .copy_from_slice(&*chunk.liquid_amount_read);
 
-        let mut terrain = Box::new([MAT_AIR; CHUNK_AREA]);
-        terrain.copy_from_slice(&*chunk.terrain);
-        snapshot.terrain.insert(chunk.coord, terrain);
+        snapshot
+            .kinds
+            .entry(chunk.coord)
+            .or_insert_with(|| Box::new([LIQ_NONE; CHUNK_AREA]))
+            .copy_from_slice(&*chunk.liquid_kind);
 
-        let mut pressures = Box::new([0u8; CHUNK_AREA]);
-        pressures.copy_from_slice(&*chunk.pressure_read);
-        snapshot.pressures.insert(chunk.coord, pressures);
+        snapshot
+            .terrain
+            .entry(chunk.coord)
+            .or_insert_with(|| Box::new([MAT_AIR; CHUNK_AREA]))
+            .copy_from_slice(&*chunk.terrain);
+
+        snapshot
+            .pressures
+            .entry(chunk.coord)
+            .or_insert_with(|| Box::new([0u8; CHUNK_AREA]))
+            .copy_from_slice(&*chunk.pressure_read);
     }
+
+    // Remove entries for chunks that no longer exist.
+    snapshot.amounts.retain(|k, _| seen.contains(k));
+    snapshot.kinds.retain(|k, _| seen.contains(k));
+    snapshot.terrain.retain(|k, _| seen.contains(k));
+    snapshot.pressures.retain(|k, _| seen.contains(k));
 }

--- a/crates/sim-fluid/src/source_drain.rs
+++ b/crates/sim-fluid/src/source_drain.rs
@@ -4,6 +4,7 @@ use tile_core::chunk::ChunkData;
 use tile_core::coords::WorldPos;
 use tile_core::liquid::{LIQ_NONE, LiquidId};
 use tile_core::material::MAT_AIR;
+use tile_core::world::World;
 
 use crate::LiquidFlags;
 
@@ -48,6 +49,7 @@ impl persistence::Persistent for LiquidDrain {
 /// Sources inject liquid; drains remove it. Both operate directly on
 /// `liquid_amount_read` so the snapshot sees the result this tick.
 pub fn run_sources_drains(
+    world_res: Res<World>,
     sources: Query<&LiquidSource>,
     drains: Query<&LiquidDrain>,
     mut chunks: Query<&mut ChunkData>,
@@ -55,43 +57,51 @@ pub fn run_sources_drains(
     for source in sources.iter() {
         let (coord, lp) = source.pos.split();
         let idx = lp.index();
-        if let Some(mut chunk) = chunks.iter_mut().find(|c| c.coord == coord) {
-            if chunk.terrain[idx] != MAT_AIR {
-                continue;
-            }
-            let current = chunk.liquid_amount_read[idx];
-            if chunk.pressure_read[idx] >= source.max_pressure && source.max_pressure > 0 {
-                continue;
-            }
-            let new_val = (current as u16 + source.rate as u16).min(255) as u8;
-            chunk.liquid_amount_read[idx] = new_val;
-            if chunk.liquid_kind[idx] == LIQ_NONE {
-                chunk.liquid_kind[idx] = source.kind;
-            }
+        let Some(&entity) = world_res.chunks.get(&coord) else {
+            continue;
+        };
+        let Ok(mut chunk) = chunks.get_mut(entity) else {
+            continue;
+        };
+        if chunk.terrain[idx] != MAT_AIR {
+            continue;
+        }
+        let current = chunk.liquid_amount_read[idx];
+        if chunk.pressure_read[idx] >= source.max_pressure && source.max_pressure > 0 {
+            continue;
+        }
+        let new_val = (current as u16 + source.rate as u16).min(255) as u8;
+        chunk.liquid_amount_read[idx] = new_val;
+        if chunk.liquid_kind[idx] == LIQ_NONE {
+            chunk.liquid_kind[idx] = source.kind;
         }
     }
 
     for drain in drains.iter() {
         let (coord, lp) = drain.pos.split();
         let idx = lp.index();
-        if let Some(mut chunk) = chunks.iter_mut().find(|c| c.coord == coord) {
-            let kind = chunk.liquid_kind[idx];
-            if kind == LIQ_NONE {
-                continue;
-            }
-            let accepted = match &drain.accepts {
-                LiquidFilter::All => true,
-                LiquidFilter::ByFlags(_) => true, // full filter in P4.8 when registry is wired
-            };
-            if !accepted {
-                continue;
-            }
-            let current = chunk.liquid_amount_read[idx];
-            let new_val = current.saturating_sub(drain.rate);
-            chunk.liquid_amount_read[idx] = new_val;
-            if new_val == 0 {
-                chunk.liquid_kind[idx] = LIQ_NONE;
-            }
+        let Some(&entity) = world_res.chunks.get(&coord) else {
+            continue;
+        };
+        let Ok(mut chunk) = chunks.get_mut(entity) else {
+            continue;
+        };
+        let kind = chunk.liquid_kind[idx];
+        if kind == LIQ_NONE {
+            continue;
+        }
+        let accepted = match &drain.accepts {
+            LiquidFilter::All => true,
+            LiquidFilter::ByFlags(_) => true, // full filter in P4.8 when registry is wired
+        };
+        if !accepted {
+            continue;
+        }
+        let current = chunk.liquid_amount_read[idx];
+        let new_val = current.saturating_sub(drain.rate);
+        chunk.liquid_amount_read[idx] = new_val;
+        if new_val == 0 {
+            chunk.liquid_kind[idx] = LIQ_NONE;
         }
     }
 }
@@ -111,6 +121,7 @@ mod tests {
         let mut app = bevy_app::App::new();
         app.init_resource::<crate::snapshot::LiquidSnapshot>();
         app.init_resource::<tile_core::activity::WakeRequests>();
+        app.init_resource::<tile_core::world::World>();
         if with_registry {
             let mut reg = crate::LiquidRegistry::default();
             for (id, props) in crate::builtin_liquids() {
@@ -150,6 +161,10 @@ mod tests {
             cz: 0,
         };
         let entity = app.world_mut().spawn(make_air_chunk(coord)).id();
+        app.world_mut()
+            .resource_mut::<tile_core::world::World>()
+            .chunks
+            .insert(coord, entity);
         app.world_mut().spawn(LiquidSource {
             pos: WorldPos { x: 5, y: 5, z: 0 },
             kind: LiquidId(1),
@@ -181,6 +196,10 @@ mod tests {
         chunk.liquid_kind[idx] = LiquidId(1);
         chunk.liquid_amount_read[idx] = 100;
         let entity = app.world_mut().spawn(chunk).id();
+        app.world_mut()
+            .resource_mut::<tile_core::world::World>()
+            .chunks
+            .insert(coord, entity);
 
         app.world_mut().spawn(LiquidDrain {
             pos: WorldPos { x: 5, y: 5, z: 0 },
@@ -209,7 +228,11 @@ mod tests {
             cy: 0,
             cz: 0,
         };
-        app.world_mut().spawn(make_air_chunk(coord));
+        let chunk_entity = app.world_mut().spawn(make_air_chunk(coord)).id();
+        app.world_mut()
+            .resource_mut::<tile_core::world::World>()
+            .chunks
+            .insert(coord, chunk_entity);
 
         // Magma source at (4, 16) — left side
         app.world_mut().spawn(LiquidSource {

--- a/crates/sim-reaction/src/resolver.rs
+++ b/crates/sim-reaction/src/resolver.rs
@@ -214,10 +214,12 @@ pub fn periodic_reaction_system(
         .buffer
         .sort_unstable_by_key(|p| (p.coord.cx, p.coord.cy, p.coord.cz, p.idx, p.reaction_id.0));
 
-    // Collect coords to find chunks by coord.
     let effects: Vec<_> = pending.buffer.drain(..).collect();
     for pe in effects {
-        if let Some(mut chunk) = chunks.iter_mut().find(|c| c.coord == pe.coord) {
+        let Some(&entity) = world_res.chunks.get(&pe.coord) else {
+            continue;
+        };
+        if let Ok(mut chunk) = chunks.get_mut(entity) {
             apply_effects(&mut chunk, pe.idx, &pe.effects);
         }
     }
@@ -247,7 +249,10 @@ pub fn liquid_collision_reaction_system(
     let tick = world_res.current_tick;
 
     for event in events.read() {
-        let Some(mut chunk) = chunks.iter_mut().find(|c| c.coord == event.coord) else {
+        let Some(&entity) = world_res.chunks.get(&event.coord) else {
+            continue;
+        };
+        let Ok(mut chunk) = chunks.get_mut(entity) else {
             continue;
         };
 
@@ -383,6 +388,10 @@ mod tests {
         chunk.terrain[42] = IRON_ORE;
         chunk.temp[42] = 1300;
         let entity = app.world_mut().spawn(chunk).id();
+        app.world_mut()
+            .resource_mut::<World>()
+            .chunks
+            .insert(COORD, entity);
 
         app.update();
 
@@ -437,6 +446,10 @@ mod tests {
         chunk.liquid_amount_read[idx] = 100;
         chunk.temp[idx] = -10; // below freezing
         let entity = app.world_mut().spawn(chunk).id();
+        app.world_mut()
+            .resource_mut::<World>()
+            .chunks
+            .insert(COORD, entity);
 
         app.update();
 
@@ -506,6 +519,10 @@ mod tests {
         let mut chunk = make_air_chunk(COORD);
         chunk.terrain[IDX] = IRON_ORE;
         let entity = app.world_mut().spawn(chunk).id();
+        app.world_mut()
+            .resource_mut::<World>()
+            .chunks
+            .insert(COORD, entity);
 
         // tick=0 → fires (0 % 4 == 0)
         app.update();
@@ -610,6 +627,10 @@ mod tests {
         chunk.liquid_kind[WATER_IDX] = WATER;
         chunk.liquid_amount_read[WATER_IDX] = 100;
         let entity = app.world_mut().spawn(chunk).id();
+        app.world_mut()
+            .resource_mut::<World>()
+            .chunks
+            .insert(COORD, entity);
 
         app.update();
 
@@ -665,6 +686,10 @@ mod tests {
         chunk.liquid_kind[OIL_IDX] = OIL; // Oil, not water
         chunk.liquid_amount_read[OIL_IDX] = 100;
         let entity = app.world_mut().spawn(chunk).id();
+        app.world_mut()
+            .resource_mut::<World>()
+            .chunks
+            .insert(COORD, entity);
 
         app.update();
 


### PR DESCRIPTION
## Summary

- **Snapshot reuse**: `snapshot_liquid` uses `entry().or_insert_with()` to reuse existing `Box<[T;1024]>` allocations instead of `clear()` + new Box per chunk. 128 chunks × 4 arrays = ~512 heap allocs/deallocs eliminated per tick.
- **pressure_propagation skip**: Chunks with no liquid and no liquid-bearing neighbors skip the per-tile loop. New `has_any_neighbor_with_liquid()` method on `LiquidSnapshot`.
- **O(1) chunk lookup**: `chunks.iter_mut().find(|c| c.coord == coord)` → `world_res.chunks.get(&coord)` + `chunks.get_mut(entity)` in `run_sources_drains`, `periodic_reaction_system`, `liquid_collision_reaction_system`, and `clear_source_terrain`.
- Test fixtures updated to register spawned chunk entities in `World.chunks`.

## Test plan

- [x] `cargo test --workspace` — all 73 tests pass
- [x] `cargo clippy --workspace` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)