### PR TITLE
feat(debug-ui): P13.2 — extended sim stats panels

### DIFF
--- a/crates/debug-ui/src/lib.rs
+++ b/crates/debug-ui/src/lib.rs
@@ -1,11 +1,22 @@
+use std::collections::{HashMap, VecDeque};
+
 use bevy::diagnostic::{
     DiagnosticsStore, EntityCountDiagnosticsPlugin, FrameTimeDiagnosticsPlugin,
 };
 use bevy::prelude::*;
 use bevy_egui::{EguiContexts, EguiPlugin, egui};
 use render_bevy::ActiveZLayer;
+use sim_fluid::LiquidRegistry;
 use sim_reaction::resolver::PendingEffects;
 use tile_core::activity::WakeRequests;
+use tile_core::chunk::ChunkData;
+use tile_core::liquid::{LIQ_NONE, LiquidId};
+
+const HISTORY_LEN: usize = 60;
+
+/// Rolling reaction-rate history (one entry per tick, last 60).
+#[derive(Resource, Default)]
+struct ReactionHistory(VecDeque<usize>);
 
 pub struct DebugUiPlugin;
 
@@ -14,10 +25,24 @@ impl Plugin for DebugUiPlugin {
         app.add_plugins(EguiPlugin)
             .add_plugins(FrameTimeDiagnosticsPlugin)
             .add_plugins(EntityCountDiagnosticsPlugin)
-            .add_systems(Update, debug_window);
+            .init_resource::<ReactionHistory>()
+            .add_systems(Update, update_reaction_history)
+            .add_systems(Update, debug_window.after(update_reaction_history));
     }
 }
 
+fn update_reaction_history(
+    pending: Option<Res<PendingEffects>>,
+    mut history: ResMut<ReactionHistory>,
+) {
+    let count = pending.map(|p| p.reactions_last_tick).unwrap_or(0);
+    if history.0.len() >= HISTORY_LEN {
+        history.0.pop_front();
+    }
+    history.0.push_back(count);
+}
+
+#[allow(clippy::too_many_arguments)]
 fn debug_window(
     mut contexts: EguiContexts,
     diagnostics: Res<DiagnosticsStore>,
@@ -25,6 +50,9 @@ fn debug_window(
     world: Res<tile_core::world::World>,
     pending_effects: Option<Res<PendingEffects>>,
     wake_requests: Option<Res<WakeRequests>>,
+    reaction_history: Res<ReactionHistory>,
+    chunks: Query<&ChunkData>,
+    liquid_reg: Option<Res<LiquidRegistry>>,
 ) {
     let fps = diagnostics
         .get(&FrameTimeDiagnosticsPlugin::FPS)
@@ -40,7 +68,7 @@ fn debug_window(
 
     egui::Window::new("Debug")
         .resizable(true)
-        .default_width(200.0)
+        .default_width(220.0)
         .show(contexts.ctx_mut(), |ui| {
             ui.collapsing("Performance", |ui| {
                 ui.label(format!("FPS:         {fps:.1}"));
@@ -48,17 +76,62 @@ fn debug_window(
             });
 
             ui.collapsing("World", |ui| {
+                let dirty = chunks.iter().filter(|c| c.dirty).count();
                 ui.label(format!("Tick:        {}", world.current_tick));
                 ui.label(format!("Z Layer:     {}", active_z.0));
                 ui.label(format!("Chunks:      {}", world.chunks.len()));
+                ui.label(format!("Dirty:       {dirty}"));
                 ui.label(format!("Entities:    {entity_count}"));
             });
 
-            ui.collapsing("Sim Internals", |ui| {
+            ui.collapsing("Fluid", |ui| {
+                let mut by_kind: HashMap<LiquidId, u64> = HashMap::new();
+                let mut active_chunks = 0usize;
+                for chunk in chunks.iter() {
+                    let mut chunk_has_liq = false;
+                    for (i, &amt) in chunk.liquid_amount_read.iter().enumerate() {
+                        if amt > 0 {
+                            chunk_has_liq = true;
+                            let kind = chunk.liquid_kind[i];
+                            *by_kind.entry(kind).or_insert(0) += amt as u64;
+                        }
+                    }
+                    if chunk_has_liq {
+                        active_chunks += 1;
+                    }
+                }
+                let pending_wake = wake_requests.as_ref().map(|w| w.pending.len()).unwrap_or(0);
+                ui.label(format!("Active chunks: {active_chunks}"));
+                ui.label(format!("Wake queue:    {pending_wake}"));
+                if by_kind.is_empty() {
+                    ui.label("No liquid");
+                } else {
+                    let mut kinds: Vec<_> = by_kind.into_iter().collect();
+                    kinds.sort_by_key(|(k, _)| k.0);
+                    for (kind, total) in kinds {
+                        if kind == LIQ_NONE {
+                            continue;
+                        }
+                        let name = liquid_reg
+                            .as_ref()
+                            .and_then(|r| r.get(kind))
+                            .map(|p| p.name.as_str())
+                            .unwrap_or("?");
+                        ui.label(format!("  [{:>3}] {:<8} {total}", kind.0, name));
+                    }
+                }
+            });
+
+            ui.collapsing("Reactions", |ui| {
                 let pending_react = pending_effects.map(|p| p.len()).unwrap_or(0);
-                let pending_wake = wake_requests.map(|w| w.pending.len()).unwrap_or(0);
-                ui.label(format!("Pending React: {pending_react}"));
-                ui.label(format!("Pending Wake:  {pending_wake}"));
+                let avg = if reaction_history.0.is_empty() {
+                    0.0
+                } else {
+                    reaction_history.0.iter().sum::<usize>() as f64
+                        / reaction_history.0.len() as f64
+                };
+                ui.label(format!("Pending:     {pending_react}"));
+                ui.label(format!("Rate (60t):  {avg:.1}/tick"));
             });
         });
 }

--- a/crates/sim-reaction/src/resolver.rs
+++ b/crates/sim-reaction/src/resolver.rs
@@ -22,6 +22,8 @@ struct PendingEffect {
 #[derive(Resource, Default)]
 pub struct PendingEffects {
     buffer: Vec<PendingEffect>,
+    /// How many periodic reactions fired last tick (set before drain, readable next frame).
+    pub reactions_last_tick: usize,
 }
 
 impl PendingEffects {
@@ -224,6 +226,7 @@ pub fn periodic_reaction_system(
         .buffer
         .sort_unstable_by_key(|p| (p.coord.cx, p.coord.cy, p.coord.cz, p.idx, p.reaction_id.0));
 
+    pending.reactions_last_tick = pending.buffer.len();
     let effects: Vec<_> = pending.buffer.drain(..).collect();
     for pe in effects {
         let Some(&entity) = world_res.chunks.get(&pe.coord) else {


### PR DESCRIPTION
## Summary

- **Fluid panel**: total liquid by kind (name from registry + amount sum), active chunks (≥1 non-zero tile), wake queue depth. Iteration is lazy — only runs when panel is open.
- **Reactions panel**: pending buffer count + 60-tick rolling average reactions/tick via `ReactionHistory` resource updated each frame.
- **World panel**: dirty chunk counter added.
- **sim-reaction**: `PendingEffects` gains `reactions_last_tick: usize` — set before buffer drain so the value is readable next frame by debug-ui.

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo test --workspace` — all pass
- [x] `cargo clippy --workspace` — clean (allow `too_many_arguments` on Bevy system fn)
- [x] `cargo fmt --all -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)