### PR TITLE
🔒 fix: Insecure Network Binding in Puffin profiler

### DIFF
--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -25,7 +25,7 @@ fn main() {
     #[cfg(feature = "profile")]
     {
         puffin::set_scopes_on(true);
-        let server_addr = format!("0.0.0.0:{}", puffin_http::DEFAULT_PORT);
+        let server_addr = format!("127.0.0.1:{}", puffin_http::DEFAULT_PORT);
         let server = puffin_http::Server::new(&server_addr).unwrap();
         eprintln!("Puffin profiler running on {}", server_addr);
         app.insert_non_send_resource(server);


### PR DESCRIPTION
🎯 **What:** Changed the Puffin profiler binding address from `0.0.0.0` to `127.0.0.1`.
⚠️ **Risk:** Binding to `0.0.0.0` allowed anyone on the network to access the profiling server, potentially exposing sensitive performance data or internal application state.
🛡️ **Solution:** Restricted the binding to the loopback interface (`127.0.0.1`), ensuring only local access is permitted.

---
*PR created automatically by Jules for task [7191077335048269429](https://jules.google.com/task/7191077335048269429) started by @Pappet*