### PR TITLE
🧹 Fix long line in crates/sim-fluid/src/lib.rs

### DIFF
--- a/crates/sim-fluid/src/lib.rs
+++ b/crates/sim-fluid/src/lib.rs
@@ -152,7 +152,9 @@ pub fn builtin_liquids() -> Vec<(LiquidId, LiquidProperties)> {
                 boils_to: GasId(0),
                 damages_living: 10,
                 corrosion: 0,
-                ignites_flammable: true, // actually it IS flammable, so doesn't instantly ignite others unless burning, but for struct properties it fits
+                // actually it IS flammable, so doesn't instantly ignite others unless burning,
+                // but for struct properties it fits
+                ignites_flammable: true,
                 color: [50, 50, 50, 255],
                 emits_light: 0,
                 flags: LiquidFlags::STAINS,


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was a line exceeding 120 characters in `crates/sim-fluid/src/lib.rs`.
💡 **Why:** Breaking long lines improves maintainability and readability of the codebase, ensuring it adheres to standard formatting limits.
✅ **Verification:** 
- Verified that no lines exceed 120 characters using `awk`.
- Ran `cargo fmt -p sim_fluid --check` to ensure the formatting is correct.
- Requested code review and received a #Correct# rating.
✨ **Result:** The code now complies with the 120-character line limit without any changes to functionality.

---
*PR created automatically by Jules for task [13667324472212710502](https://jules.google.com/task/13667324472212710502) started by @Pappet*