### PR TITLE
⚡ Bolt: [array zero check SIMD optimization]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Array Comparison Optimization
+**Learning:** In Rust fixed-size array checks, checking for non-zero elements using `iter().any(|&x| x > 0)` is significantly slower than `*arr != [0u8; SIZE]` because LLVM can easily auto-vectorize the latter into SIMD memcmp instructions.
+**Action:** Replace iterator chains over large fixed-size byte arrays with direct comparisons to zeroed arrays where performance is critical.

--- a/crates/sim-fluid/src/fluid_ca.rs
+++ b/crates/sim-fluid/src/fluid_ca.rs
@@ -63,7 +63,8 @@ pub fn flow_with_pressure(
 pub fn pressure_propagation(mut chunks: Query<&mut ChunkData>, snapshot: Res<LiquidSnapshot>) {
     for mut chunk in chunks.iter_mut() {
         let coord = chunk.coord;
-        let has_liquid = chunk.liquid_amount_read.iter().any(|&a| a > 0);
+        // ⚡ Bolt: Fast SIMD array comparison
+        let has_liquid = *chunk.liquid_amount_read != [0u8; CHUNK_AREA];
         if !has_liquid && !snapshot.has_any_neighbor_with_liquid(coord) {
             chunk.pressure_write.fill(0);
             continue;
@@ -171,7 +172,8 @@ pub fn fluid_step_local(
 ) {
     for mut chunk in chunks.iter_mut() {
         let coord = chunk.coord;
-        let has_liquid = chunk.liquid_amount_read.iter().any(|&a| a > 0);
+        // ⚡ Bolt: Fast SIMD array comparison
+        let has_liquid = *chunk.liquid_amount_read != [0u8; CHUNK_AREA];
         if !has_liquid && !snapshot.has_any_neighbor(coord) {
             continue;
         }

--- a/crates/sim-fluid/src/snapshot.rs
+++ b/crates/sim-fluid/src/snapshot.rs
@@ -40,7 +40,8 @@ impl LiquidSnapshot {
     pub fn chunk_has_liquid(&self, coord: ChunkCoord) -> bool {
         self.amounts
             .get(&coord)
-            .is_some_and(|a| a.iter().any(|&v| v > 0))
+            // ⚡ Bolt: Fast SIMD array comparison
+            .is_some_and(|a| **a != [0u8; CHUNK_AREA])
     }
 
     /// True if any of the 4 horizontal neighbor chunks exist in the snapshot.

--- a/crates/sim-fluid/src/vertical_flow.rs
+++ b/crates/sim-fluid/src/vertical_flow.rs
@@ -26,7 +26,8 @@ pub fn liquid_vertical_flow(
 ) {
     for mut chunk in chunks.iter_mut() {
         let coord = chunk.coord;
-        let has_liquid = chunk.liquid_amount_read.iter().any(|&a| a > 0);
+        // ⚡ Bolt: Fast SIMD array comparison
+        let has_liquid = *chunk.liquid_amount_read != [0u8; CHUNK_AREA];
 
         // Check if chunk above has liquid that could fall into us
         let above = ChunkCoord {


### PR DESCRIPTION
💡 What: Replaced `.iter().any(|&a| a > 0)` checks with direct zero array comparisons (`*arr != [0u8; CHUNK_AREA]`) in `sim-fluid`.

🎯 Why: In Rust, iterator-based validation over large fixed-size arrays (`any(|&a| a > 0)`) can be slower due to un-vectorized byte-by-byte iteration checks. Doing a direct equality comparison against an equivalent-sized zero-initialized array allows LLVM to automatically vectorize the instruction, resulting in the utilization of fast SIMD/memcmp block comparisons. Since `u8` cannot be negative, checking if there are non-zero elements using `> 0` logic is strictly equivalent to evaluating if the block is not completely zero.

📊 Impact: Reduces cycle time across core fluid ca functions executing loop updates across many `[u8; CHUNK_AREA]` sizes globally.

🔬 Measurement: Local test executions pass. Performance can be profiled via CPU instruction-level profiling and observing lower invocation overhead.

---
*PR created automatically by Jules for task [13944912595452783665](https://jules.google.com/task/13944912595452783665) started by @Pappet*