### PR TITLE
⚡ Bolt: Optimize periodic reaction lookups by pre-filtering

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-15 - Optimize Periodic Reaction Lookups
+**Learning:** In highly-iterative ECS environments like `sim-reaction`, looking up conditions that don't depend on ECS iteration inside a loop over components multiplies overhead. Here we observed `O(Chunks * TotalReactions)` which performed unnecessary `is_multiple_of` checks repeatedly.
+**Action:** Always inspect inner loops for values that remain constant across iterations. Hoist computations and lookups to `O(TotalReactions + Chunks * ActiveReactions)` when it evaluates purely external/non-entity criteria like system time/ticks.

--- a/crates/sim-reaction/src/resolver.rs
+++ b/crates/sim-reaction/src/resolver.rs
@@ -165,23 +165,35 @@ pub fn periodic_reaction_system(
         return;
     }
 
+    // Pre-filter active periodic reactions for this tick.
+    // Optimization: Pre-filtering and pre-fetching active registry entries
+    // outside of hot chunk/tile loops significantly reduces redundant work.
+    let mut active_reactions = Vec::new();
+    for rid in periodic_ids {
+        let reaction = match registry.get(*rid) {
+            Some(r) => r,
+            None => continue,
+        };
+
+        // Periodic phase-offset: skip ticks where (tick % every_ticks) != 0.
+        let crate::Trigger::Periodic { every_ticks } = reaction.trigger else {
+            continue;
+        };
+        if every_ticks > 0 && !tick.is_multiple_of(every_ticks as u64) {
+            continue;
+        }
+
+        active_reactions.push((*rid, reaction));
+    }
+
+    if active_reactions.is_empty() {
+        return;
+    }
+
     // Phase 1: collect pending effects (immutable chunk reads).
     for chunk in chunks.iter() {
         let coord = chunk.coord;
-        for rid in periodic_ids {
-            let reaction = match registry.get(*rid) {
-                Some(r) => r,
-                None => continue,
-            };
-
-            // Periodic phase-offset: skip ticks where (tick % every_ticks) != 0.
-            let crate::Trigger::Periodic { every_ticks } = reaction.trigger else {
-                continue;
-            };
-            if every_ticks > 0 && !tick.is_multiple_of(every_ticks as u64) {
-                continue;
-            }
-
+        for (rid, reaction) in &active_reactions {
             for idx in 0..tile_core::coords::CHUNK_AREA {
                 if let Some(min_t) = reaction.min_temperature
                     && chunk.temp[idx] < min_t


### PR DESCRIPTION
💡 What: Extracted the active reaction filtering and fetching logic out of the main `chunk` iteration loop inside `periodic_reaction_system` in `crates/sim-reaction/src/resolver.rs`.

🎯 Why: During each tick, the ECS system was scanning through every single chunk and individually testing each periodic reaction (from `registry.by_trigger`) to verify if its phase-offset hit (e.g. `tick.is_multiple_of(every_ticks)`). This forced redundant tick arithmetic and registry lookups repeatedly for each chunk (`O(Chunks * PeriodicReactions)`). Hoisting it limits these checks to once per tick (`O(PeriodicReactions)`).

📊 Impact: Reduces redundant tick checks and lookup iterations across all loaded chunks by isolating work to active reactions only per tick. 

🔬 Measurement: Cargo tests for `sim-reaction` verify correctness by passing locally. The overall latency drops and performance scales much better as the number of active chunks increases.

---
*PR created automatically by Jules for task [12299727670712715691](https://jules.google.com/task/12299727670712715691) started by @Pappet*