### PR TITLE
⚡ Bolt: Optimize chunk-level liquid checks via snapshot caching

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Caching `has_liquid` per chunk in LiquidSnapshot
+**Learning:** Checking whether a chunk has liquid by iterating over its array is an O(N) check per step, per chunk, per simulation system. By pre-computing and storing a simple `has_liquid` boolean in `LiquidSnapshot` during the `PreTick` phase, we can significantly reduce duplicated calculations during liquid CA and vertical flow steps.
+**Action:** Always look for O(N) array calculations inside nested loops that remain static during a tick and move them into the snapshotting phase where they are only evaluated once.

--- a/crates/sim-fluid/src/fluid_ca.rs
+++ b/crates/sim-fluid/src/fluid_ca.rs
@@ -63,7 +63,7 @@ pub fn flow_with_pressure(
 pub fn pressure_propagation(mut chunks: Query<&mut ChunkData>, snapshot: Res<LiquidSnapshot>) {
     for mut chunk in chunks.iter_mut() {
         let coord = chunk.coord;
-        let has_liquid = chunk.liquid_amount_read.iter().any(|&a| a > 0);
+        let has_liquid = snapshot.chunk_has_liquid(coord);
         if !has_liquid && !snapshot.has_any_neighbor_with_liquid(coord) {
             chunk.pressure_write.fill(0);
             continue;
@@ -171,7 +171,7 @@ pub fn fluid_step_local(
 ) {
     for mut chunk in chunks.iter_mut() {
         let coord = chunk.coord;
-        let has_liquid = chunk.liquid_amount_read.iter().any(|&a| a > 0);
+        let has_liquid = snapshot.chunk_has_liquid(coord);
         if !has_liquid && !snapshot.has_any_neighbor(coord) {
             continue;
         }

--- a/crates/sim-fluid/src/snapshot.rs
+++ b/crates/sim-fluid/src/snapshot.rs
@@ -15,6 +15,7 @@ pub struct LiquidSnapshot {
     kinds: HashMap<ChunkCoord, Box<[LiquidId; CHUNK_AREA]>>,
     terrain: HashMap<ChunkCoord, Box<[MaterialId; CHUNK_AREA]>>,
     pressures: HashMap<ChunkCoord, Box<[u8; CHUNK_AREA]>>,
+    has_liquid: HashMap<ChunkCoord, bool>,
 }
 
 impl LiquidSnapshot {
@@ -38,9 +39,7 @@ impl LiquidSnapshot {
 
     /// True if chunk exists in snapshot and has any non-zero liquid amount.
     pub fn chunk_has_liquid(&self, coord: ChunkCoord) -> bool {
-        self.amounts
-            .get(&coord)
-            .is_some_and(|a| a.iter().any(|&v| v > 0))
+        self.has_liquid.get(&coord).copied().unwrap_or(false)
     }
 
     /// True if any of the 4 horizontal neighbor chunks exist in the snapshot.
@@ -121,6 +120,9 @@ pub fn snapshot_liquid(mut snapshot: ResMut<LiquidSnapshot>, chunks: Query<&Chun
             .or_insert_with(|| Box::new([0u8; CHUNK_AREA]))
             .copy_from_slice(&*chunk.liquid_amount_read);
 
+        let has_liq = chunk.liquid_amount_read.iter().any(|&v| v > 0);
+        snapshot.has_liquid.insert(chunk.coord, has_liq);
+
         snapshot
             .kinds
             .entry(chunk.coord)
@@ -145,4 +147,5 @@ pub fn snapshot_liquid(mut snapshot: ResMut<LiquidSnapshot>, chunks: Query<&Chun
     snapshot.kinds.retain(|k, _| seen.contains(k));
     snapshot.terrain.retain(|k, _| seen.contains(k));
     snapshot.pressures.retain(|k, _| seen.contains(k));
+    snapshot.has_liquid.retain(|k, _| seen.contains(k));
 }

--- a/crates/sim-fluid/src/vertical_flow.rs
+++ b/crates/sim-fluid/src/vertical_flow.rs
@@ -26,7 +26,7 @@ pub fn liquid_vertical_flow(
 ) {
     for mut chunk in chunks.iter_mut() {
         let coord = chunk.coord;
-        let has_liquid = chunk.liquid_amount_read.iter().any(|&a| a > 0);
+        let has_liquid = snapshot.chunk_has_liquid(coord);
 
         // Check if chunk above has liquid that could fall into us
         let above = ChunkCoord {


### PR DESCRIPTION
💡 What: Added a cached `has_liquid` boolean lookup to `LiquidSnapshot`, evaluated once per chunk during `PreTick`, to eliminate the need for `chunk.liquid_amount_read.iter().any(|&a| a > 0)` checks in multiple hot simulation loops.

🎯 Why: Before this change, the cellular automata and vertical flow systems performed full O(N) iterations (N=1024 tiles per chunk) inside their update loops just to check if the chunk had any liquid. By extracting and pre-calculating this aggregate flag during the pre-existing snapshot pass, we drop an entire layer of repetitive inner loops.

📊 Impact: Reduces redundant O(N) array scans during multi-pass liquid resolution steps down to a single constant-time hashmap lookup per chunk. Should significantly lower the baseline CPU overhead per chunk on standard fluid iterations.

🔬 Measurement: Run `cargo run -p app --features profile` to verify reductions in `fluid_ca` and `vertical_flow` system span times across large volumes of chunks. Run tests to confirm zero regressions in determinism.

---
*PR created automatically by Jules for task [7449829226790605541](https://jules.google.com/task/7449829226790605541) started by @Pappet*