### PR TITLE
⚡ Bolt: [Performance] Pre-filter active periodic reactions

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Periodic Reaction Loop Optimization
+**Learning:** Optimizing simulation systems (like periodic_reaction_system) by pre-filtering and pre-fetching active registry entries into a Vec outside of hot chunk/tile loops significantly reduces redundant work from O(Chunks * TotalReactions) to O(TotalReactions + Chunks * ActiveReactions).
+**Action:** Extract the active reactions into a `Vec` *before* iterating over chunks.

--- a/crates/sim-reaction/src/resolver.rs
+++ b/crates/sim-reaction/src/resolver.rs
@@ -165,23 +165,30 @@ pub fn periodic_reaction_system(
         return;
     }
 
-    // Phase 1: collect pending effects (immutable chunk reads).
-    for chunk in chunks.iter() {
-        let coord = chunk.coord;
-        for rid in periodic_ids {
-            let reaction = match registry.get(*rid) {
-                Some(r) => r,
-                None => continue,
-            };
-
-            // Periodic phase-offset: skip ticks where (tick % every_ticks) != 0.
+    // PERFORMANCE OPTIMIZATION:
+    // Pre-filtering and fetching active reactions into a `Vec` outside of the hot chunk/tile loop.
+    // This reduces redundant work from O(Chunks * TotalReactions) to O(TotalReactions + Chunks * ActiveReactions).
+    let mut active_reactions = Vec::new();
+    for rid in periodic_ids {
+        if let Some(reaction) = registry.get(*rid) {
             let crate::Trigger::Periodic { every_ticks } = reaction.trigger else {
                 continue;
             };
-            if every_ticks > 0 && !tick.is_multiple_of(every_ticks as u64) {
-                continue;
+            // Periodic phase-offset: skip ticks where (tick % every_ticks) != 0.
+            if every_ticks == 0 || tick.is_multiple_of(every_ticks as u64) {
+                active_reactions.push((*rid, reaction));
             }
+        }
+    }
 
+    if active_reactions.is_empty() {
+        return;
+    }
+
+    // Phase 1: collect pending effects (immutable chunk reads).
+    for chunk in chunks.iter() {
+        let coord = chunk.coord;
+        for (rid, reaction) in &active_reactions {
             for idx in 0..tile_core::coords::CHUNK_AREA {
                 if let Some(min_t) = reaction.min_temperature
                     && chunk.temp[idx] < min_t


### PR DESCRIPTION
💡 **What**: Pre-filtered the active periodic reactions into a `Vec` prior to evaluating the hot outer loop over `chunks.iter()`. Added code comments and documented the performance insight in `.jules/bolt.md`.
🎯 **Why**: The `periodic_reaction_system` was iterating over all `periodic_ids` for every chunk and verifying whether it was active for the `every_ticks` check. This caused O(Chunks * TotalReactions) redundant work.
📊 **Impact**: Reduces redundant lookup loops from `O(Chunks * TotalReactions)` to `O(TotalReactions + Chunks * ActiveReactions)`, speeding up the core reactor ticks.
🔬 **Measurement**: Verify by profiling with `puffin` via `cargo run -p app --features profile`.

---
*PR created automatically by Jules for task [16182341399034168799](https://jules.google.com/task/16182341399034168799) started by @Pappet*