### PR TITLE
⚡ Bolt: Cache chunk_has_liquid in LiquidSnapshot

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,4 @@
+
+## 2024-05-19 - Cache Derived Aggregate Statistics per Chunk Early
+**Learning:** Derived chunk-level aggregates (like determining if a chunk `has_liquid` by scanning O(Area) tiles) should be calculated and cached during the initial `PreTick` snapshot phase rather than repeatedly during multi-pass cellular automata systems, avoiding expensive repeated scans.
+**Action:** When a simulation requires aggregates or checks across an entire chunk's data in the inner loop, cache it into `LiquidSnapshot` or a similar struct at snapshotting time for O(1) reads later.

--- a/crates/sim-fluid/src/snapshot.rs
+++ b/crates/sim-fluid/src/snapshot.rs
@@ -15,6 +15,8 @@ pub struct LiquidSnapshot {
     kinds: HashMap<ChunkCoord, Box<[LiquidId; CHUNK_AREA]>>,
     terrain: HashMap<ChunkCoord, Box<[MaterialId; CHUNK_AREA]>>,
     pressures: HashMap<ChunkCoord, Box<[u8; CHUNK_AREA]>>,
+    // ⚡ Bolt: Cache whether the chunk has liquid to avoid repeated O(Area) scans during CA multi-pass.
+    has_liquid: HashMap<ChunkCoord, bool>,
 }
 
 impl LiquidSnapshot {
@@ -38,9 +40,7 @@ impl LiquidSnapshot {
 
     /// True if chunk exists in snapshot and has any non-zero liquid amount.
     pub fn chunk_has_liquid(&self, coord: ChunkCoord) -> bool {
-        self.amounts
-            .get(&coord)
-            .is_some_and(|a| a.iter().any(|&v| v > 0))
+        self.has_liquid.get(&coord).copied().unwrap_or(false)
     }
 
     /// True if any of the 4 horizontal neighbor chunks exist in the snapshot.
@@ -138,6 +138,9 @@ pub fn snapshot_liquid(mut snapshot: ResMut<LiquidSnapshot>, chunks: Query<&Chun
             .entry(chunk.coord)
             .or_insert_with(|| Box::new([0u8; CHUNK_AREA]))
             .copy_from_slice(&*chunk.pressure_read);
+
+        let has_liq = chunk.liquid_amount_read.iter().any(|&v| v > 0);
+        snapshot.has_liquid.insert(chunk.coord, has_liq);
     }
 
     // Remove entries for chunks that no longer exist.
@@ -145,4 +148,5 @@ pub fn snapshot_liquid(mut snapshot: ResMut<LiquidSnapshot>, chunks: Query<&Chun
     snapshot.kinds.retain(|k, _| seen.contains(k));
     snapshot.terrain.retain(|k, _| seen.contains(k));
     snapshot.pressures.retain(|k, _| seen.contains(k));
+    snapshot.has_liquid.retain(|k, _| seen.contains(k));
 }


### PR DESCRIPTION
💡 What: Replaced the O(Area) iteration in `chunk_has_liquid` with an O(1) cached lookup populated during the `LiquidSnapshot` initialization in the `PreTick` phase.
🎯 Why: Multi-pass cellular automata systems query `chunk_has_liquid` repeatedly to short-circuit updates for empty chunks. Scanning the entire 32x32 chunk array on every query causes redundant work. Caching this derived aggregate prevents this bottleneck.
📊 Impact: Reduces the overhead of checking for liquid presence in inactive or empty regions from O(Area) per query to O(1) lookup.
🔬 Measurement: Verify with `cargo run -p app --features profile` by observing a reduction in time spent in `fluid_ca` loops when many inactive chunks are present.

---
*PR created automatically by Jules for task [5977195367241720649](https://jules.google.com/task/5977195367241720649) started by @Pappet*