### PR TITLE
⚡ Bolt: Cache chunk_has_liquid aggregate in LiquidSnapshot

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-20 - Cache Chunk-Level Aggregates in Snapshot
+**Learning:** Checking if a chunk has any liquid by iterating over all tiles repeatedly (`iter().any()`) inside multi-pass cellular automata systems (`pressure_propagation`, `fluid_step_local`, `liquid_vertical_flow`) is inefficient, as chunk data is frozen per tick.
+**Action:** Derived chunk-level aggregates (like `chunk_has_liquid`) should be cached in the `LiquidSnapshot` during the PreTick phase rather than being re-calculated repeatedly on the fly.

--- a/crates/sim-fluid/src/fluid_ca.rs
+++ b/crates/sim-fluid/src/fluid_ca.rs
@@ -63,7 +63,7 @@ pub fn flow_with_pressure(
 pub fn pressure_propagation(mut chunks: Query<&mut ChunkData>, snapshot: Res<LiquidSnapshot>) {
     for mut chunk in chunks.iter_mut() {
         let coord = chunk.coord;
-        let has_liquid = chunk.liquid_amount_read.iter().any(|&a| a > 0);
+        let has_liquid = snapshot.chunk_has_liquid(coord);
         if !has_liquid && !snapshot.has_any_neighbor_with_liquid(coord) {
             chunk.pressure_write.fill(0);
             continue;
@@ -171,7 +171,7 @@ pub fn fluid_step_local(
 ) {
     for mut chunk in chunks.iter_mut() {
         let coord = chunk.coord;
-        let has_liquid = chunk.liquid_amount_read.iter().any(|&a| a > 0);
+        let has_liquid = snapshot.chunk_has_liquid(coord);
         if !has_liquid && !snapshot.has_any_neighbor(coord) {
             continue;
         }

--- a/crates/sim-fluid/src/snapshot.rs
+++ b/crates/sim-fluid/src/snapshot.rs
@@ -15,6 +15,7 @@ pub struct LiquidSnapshot {
     kinds: HashMap<ChunkCoord, Box<[LiquidId; CHUNK_AREA]>>,
     terrain: HashMap<ChunkCoord, Box<[MaterialId; CHUNK_AREA]>>,
     pressures: HashMap<ChunkCoord, Box<[u8; CHUNK_AREA]>>,
+    has_liquid: HashMap<ChunkCoord, bool>,
 }
 
 impl LiquidSnapshot {
@@ -38,9 +39,7 @@ impl LiquidSnapshot {
 
     /// True if chunk exists in snapshot and has any non-zero liquid amount.
     pub fn chunk_has_liquid(&self, coord: ChunkCoord) -> bool {
-        self.amounts
-            .get(&coord)
-            .is_some_and(|a| a.iter().any(|&v| v > 0))
+        self.has_liquid.get(&coord).copied().unwrap_or(false)
     }
 
     /// True if any of the 4 horizontal neighbor chunks exist in the snapshot.
@@ -115,6 +114,9 @@ pub fn snapshot_liquid(mut snapshot: ResMut<LiquidSnapshot>, chunks: Query<&Chun
     for chunk in chunks.iter() {
         seen.insert(chunk.coord);
 
+        let has_liq = chunk.liquid_amount_read.iter().any(|&v| v > 0);
+        snapshot.has_liquid.insert(chunk.coord, has_liq);
+
         snapshot
             .amounts
             .entry(chunk.coord)
@@ -145,4 +147,5 @@ pub fn snapshot_liquid(mut snapshot: ResMut<LiquidSnapshot>, chunks: Query<&Chun
     snapshot.kinds.retain(|k, _| seen.contains(k));
     snapshot.terrain.retain(|k, _| seen.contains(k));
     snapshot.pressures.retain(|k, _| seen.contains(k));
+    snapshot.has_liquid.retain(|k, _| seen.contains(k));
 }

--- a/crates/sim-fluid/src/vertical_flow.rs
+++ b/crates/sim-fluid/src/vertical_flow.rs
@@ -26,7 +26,7 @@ pub fn liquid_vertical_flow(
 ) {
     for mut chunk in chunks.iter_mut() {
         let coord = chunk.coord;
-        let has_liquid = chunk.liquid_amount_read.iter().any(|&a| a > 0);
+        let has_liquid = snapshot.chunk_has_liquid(coord);
 
         // Check if chunk above has liquid that could fall into us
         let above = ChunkCoord {


### PR DESCRIPTION
💡 What: Added a `has_liquid` cache map to the `LiquidSnapshot` generated during the PreTick phase, and updated all multi-pass cellular automata systems (`pressure_propagation`, `fluid_step_local`, `liquid_vertical_flow`) to use this cached lookup instead of repeatedly scanning the 1024-element `liquid_amount_read` array.
🎯 Why: Because `liquid_amount_read` is double-buffered and frozen per tick, scanning it repeatedly inside tight multi-pass CA loops is redundant O(N) work (where N is `CHUNK_AREA`).
📊 Impact: Eliminates ~3 redundant 1024-element iterator scans per active chunk per tick in the fluid simulation, significantly reducing main thread overhead for fluid physics.
🔬 Measurement: Verify by running tests (`cargo test -p sim_fluid`) to ensure simulation behavior remains correct and identical, and running profiling (`cargo run -p app --features profile`) to observe reduced CPU usage in fluid CA systems.

---
*PR created automatically by Jules for task [15436446547735425557](https://jules.google.com/task/15436446547735425557) started by @Pappet*