### PR TITLE
⚡ Bolt: Pre-filter active reactions outside of chunk loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-21 - Pre-filtering active registry entries
+**Learning:** In systems that iterate over many chunks or tiles, performing registry lookups and condition checks (like tick intervals) for every reaction inside the hot loop causes massive redundant work.
+**Action:** Always pre-filter and pre-fetch active registry entries into a local Vec *before* the spatial loops. This shifts complexity from O(Chunks * TotalReactions) to O(TotalReactions + Chunks * ActiveReactions).

--- a/crates/sim-reaction/src/resolver.rs
+++ b/crates/sim-reaction/src/resolver.rs
@@ -165,23 +165,29 @@ pub fn periodic_reaction_system(
         return;
     }
 
+    // Performance optimization: Pre-filter active reactions to avoid
+    // doing a registry lookup and tick-multiple check for every chunk
+    // shifting time complexity from O(Chunks * TotalReactions) to
+    // O(TotalReactions + Chunks * ActiveReactions).
+    let mut active_reactions = Vec::with_capacity(periodic_ids.len());
+    for rid in periodic_ids {
+        if let Some(reaction) = registry.get(*rid) {
+            if let crate::Trigger::Periodic { every_ticks } = reaction.trigger {
+                if every_ticks == 0 || tick.is_multiple_of(every_ticks as u64) {
+                    active_reactions.push((*rid, reaction));
+                }
+            }
+        }
+    }
+
+    if active_reactions.is_empty() {
+        return;
+    }
+
     // Phase 1: collect pending effects (immutable chunk reads).
     for chunk in chunks.iter() {
         let coord = chunk.coord;
-        for rid in periodic_ids {
-            let reaction = match registry.get(*rid) {
-                Some(r) => r,
-                None => continue,
-            };
-
-            // Periodic phase-offset: skip ticks where (tick % every_ticks) != 0.
-            let crate::Trigger::Periodic { every_ticks } = reaction.trigger else {
-                continue;
-            };
-            if every_ticks > 0 && !tick.is_multiple_of(every_ticks as u64) {
-                continue;
-            }
-
+        for (rid, reaction) in &active_reactions {
             for idx in 0..tile_core::coords::CHUNK_AREA {
                 if let Some(min_t) = reaction.min_temperature
                     && chunk.temp[idx] < min_t

--- a/crates/sim-reaction/src/resolver.rs
+++ b/crates/sim-reaction/src/resolver.rs
@@ -171,12 +171,11 @@ pub fn periodic_reaction_system(
     // O(TotalReactions + Chunks * ActiveReactions).
     let mut active_reactions = Vec::with_capacity(periodic_ids.len());
     for rid in periodic_ids {
-        if let Some(reaction) = registry.get(*rid) {
-            if let crate::Trigger::Periodic { every_ticks } = reaction.trigger {
-                if every_ticks == 0 || tick.is_multiple_of(every_ticks as u64) {
-                    active_reactions.push((*rid, reaction));
-                }
-            }
+        if let Some(reaction) = registry.get(*rid)
+            && let crate::Trigger::Periodic { every_ticks } = reaction.trigger
+            && (every_ticks == 0 || tick.is_multiple_of(every_ticks as u64))
+        {
+            active_reactions.push((*rid, reaction));
         }
     }
 


### PR DESCRIPTION
💡 **What:**
Pre-filtered active periodic reactions outside of the `chunks.iter()` loop in `periodic_reaction_system`.

🎯 **Why:**
The previous implementation performed a registry lookup and evaluated the `every_ticks` condition for *every single reaction* against *every single chunk*. Since the registry and tick do not change per chunk, this did an enormous amount of redundant work (`O(Chunks * TotalReactions)`).

📊 **Impact:**
Shifts time complexity from `O(Chunks * TotalReactions)` to `O(TotalReactions + Chunks * ActiveReactions)`. In a large world with many chunks and many registered periodic reactions, this significantly speeds up the pre-tick phase by doing lookups exactly once per tick instead of thousands of times.

🔬 **Measurement:**
Profiling the pre-tick simulation phase (e.g. via `cargo run -p app --features profile`) should show a noticeable reduction in time spent in `periodic_reaction_system`, especially when scaling chunk count or reaction registry size. The `cargo test --workspace` suite passes fully, verifying determinism and logic are unchanged.

---
*PR created automatically by Jules for task [5700210733784038285](https://jules.google.com/task/5700210733784038285) started by @Pappet*