### PR TITLE
⚡ Bolt: Optimize `chunk_has_liquid` with PreTick caching

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-22 - [Optimize Liquid Snapshot Caching]
+**Learning:** Checking if a chunk has any non-zero liquid amounts using `.iter().any(|&v| v > 0)` is expensive when called repeatedly for the same chunk across multiple passes and neighbor checks.
+**Action:** Pre-compute and cache derived chunk-level aggregations (like `chunk_has_liquid`) into `LiquidSnapshot` during the PreTick phase to avoid recalculating it multiple times inside multi-pass cellular automata systems.

--- a/crates/sim-fluid/src/snapshot.rs
+++ b/crates/sim-fluid/src/snapshot.rs
@@ -15,6 +15,7 @@ pub struct LiquidSnapshot {
     kinds: HashMap<ChunkCoord, Box<[LiquidId; CHUNK_AREA]>>,
     terrain: HashMap<ChunkCoord, Box<[MaterialId; CHUNK_AREA]>>,
     pressures: HashMap<ChunkCoord, Box<[u8; CHUNK_AREA]>>,
+    chunk_has_liquid_cache: HashMap<ChunkCoord, bool>,
 }
 
 impl LiquidSnapshot {
@@ -38,9 +39,10 @@ impl LiquidSnapshot {
 
     /// True if chunk exists in snapshot and has any non-zero liquid amount.
     pub fn chunk_has_liquid(&self, coord: ChunkCoord) -> bool {
-        self.amounts
+        self.chunk_has_liquid_cache
             .get(&coord)
-            .is_some_and(|a| a.iter().any(|&v| v > 0))
+            .copied()
+            .unwrap_or(false)
     }
 
     /// True if any of the 4 horizontal neighbor chunks exist in the snapshot.
@@ -115,6 +117,11 @@ pub fn snapshot_liquid(mut snapshot: ResMut<LiquidSnapshot>, chunks: Query<&Chun
     for chunk in chunks.iter() {
         seen.insert(chunk.coord);
 
+        let has_liquid = chunk.liquid_amount_read.iter().any(|&v| v > 0);
+        snapshot
+            .chunk_has_liquid_cache
+            .insert(chunk.coord, has_liquid);
+
         snapshot
             .amounts
             .entry(chunk.coord)
@@ -145,4 +152,7 @@ pub fn snapshot_liquid(mut snapshot: ResMut<LiquidSnapshot>, chunks: Query<&Chun
     snapshot.kinds.retain(|k, _| seen.contains(k));
     snapshot.terrain.retain(|k, _| seen.contains(k));
     snapshot.pressures.retain(|k, _| seen.contains(k));
+    snapshot
+        .chunk_has_liquid_cache
+        .retain(|k, _| seen.contains(k));
 }


### PR DESCRIPTION
💡 What:
Pre-computes and caches whether a chunk has any non-zero liquid amounts (`has_liquid`) into the `LiquidSnapshot` during the PreTick phase, and reads from this cache in `chunk_has_liquid()` instead of recalculating it.

🎯 Why:
In the cellular automata simulation, neighbor checks happen extremely frequently across multiple passes. Recalculating `chunk.liquid_amount_read.iter().any(|&v| v > 0)` requires an O(CHUNK_AREA) iteration every time `chunk_has_liquid` is called, representing a significant source of redundant computation. Caching this in a HashMap avoids this overhead.

📊 Impact:
Eliminates O(CHUNK_AREA) iteration per `chunk_has_liquid()` call, reducing it to an O(1) HashMap lookup. This will measurably decrease CPU time spent during fluid CA update passes, especially in regions with active fluid flows across chunk boundaries.

🔬 Measurement:
Run simulation with puffin/tracy profiler (`cargo run -p app --features profile`) and observe reduced CPU time in fluid processing systems, specifically reduced time spent in neighbor checking logic compared to baseline.

---
*PR created automatically by Jules for task [14384910288438333558](https://jules.google.com/task/14384910288438333558) started by @Pappet*