### PR TITLE
⚡ Bolt: Pre-filter active periodic reactions to avoid redundant chunk iteration work

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-05-23 - Pre-filter active periodic reactions
+**Learning:** Optimizing simulation systems by pre-filtering and pre-fetching active registry entries into a `Vec` outside of hot chunk/tile loops significantly reduces redundant work from O(Chunks * TotalReactions) to O(TotalReactions + Chunks * ActiveReactions).
+**Action:** Pre-filter active reactions outside of chunk loops in simulation systems.

--- a/crates/sim-reaction/src/resolver.rs
+++ b/crates/sim-reaction/src/resolver.rs
@@ -165,23 +165,29 @@ pub fn periodic_reaction_system(
         return;
     }
 
-    // Phase 1: collect pending effects (immutable chunk reads).
-    for chunk in chunks.iter() {
-        let coord = chunk.coord;
-        for rid in periodic_ids {
-            let reaction = match registry.get(*rid) {
-                Some(r) => r,
-                None => continue,
-            };
-
+    // Bolt: Pre-filter active reactions outside of the chunk loop to avoid redundant
+    // registry lookups and modulo math (O(Chunks * TotalReactions) -> O(Chunks * ActiveReactions)).
+    let mut active_reactions = Vec::with_capacity(periodic_ids.len());
+    for rid in periodic_ids {
+        if let Some(reaction) = registry.get(*rid) {
             // Periodic phase-offset: skip ticks where (tick % every_ticks) != 0.
             let crate::Trigger::Periodic { every_ticks } = reaction.trigger else {
                 continue;
             };
-            if every_ticks > 0 && !tick.is_multiple_of(every_ticks as u64) {
-                continue;
+            if every_ticks == 0 || tick.is_multiple_of(every_ticks as u64) {
+                active_reactions.push((*rid, reaction));
             }
+        }
+    }
 
+    if active_reactions.is_empty() {
+        return;
+    }
+
+    // Phase 1: collect pending effects (immutable chunk reads).
+    for chunk in chunks.iter() {
+        let coord = chunk.coord;
+        for (rid, reaction) in &active_reactions {
             for idx in 0..tile_core::coords::CHUNK_AREA {
                 if let Some(min_t) = reaction.min_temperature
                     && chunk.temp[idx] < min_t


### PR DESCRIPTION
💡 **What:** 
Hoisted the `ReactionRegistry` lookup and `tick.is_multiple_of` phase-offset checking for periodic reactions out of the `chunks` iteration loop inside `periodic_reaction_system`. Active reactions are now pre-filtered and pre-fetched into a `Vec` for the current tick before the simulation iterates over the chunks.

🎯 **Why:** 
Previously, the system would perform a hashmap lookup in `ReactionRegistry` and a modulo operation on `current_tick` for every single periodic reaction, inside every single chunk loop. This resulted in `O(Chunks * TotalReactions)` operations per tick. This optimization brings it down to `O(TotalReactions + Chunks * ActiveReactions)`, eliminating redundant lookups and math for reactions that shouldn't even trigger on the current tick. 

📊 **Impact:** 
Significantly reduces unnecessary CPU cycles per tick spent on modulo math and registry hashmap lookups. This improves worst-case tick latency as the number of chunks and total periodic reactions scale up, at the negligible cost of a small, tick-local `Vec` allocation. 

🔬 **Measurement:** 
Run `cargo test -p sim-reaction` to ensure behavioral determinism is preserved, and test standard simulation speed with profiling.

---
*PR created automatically by Jules for task [896938490245822235](https://jules.google.com/task/896938490245822235) started by @Pappet*