### PR TITLE
⚡ Bolt: Cache chunk liquid presence in snapshot

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Cache derived chunk aggregates in LiquidSnapshot
+**Learning:** Derived chunk-level aggregates (like checking if a chunk has any liquid) should be cached in the `LiquidSnapshot` during the PreTick phase, rather than recalculating them repeatedly by iterating over chunk data inside multi-pass CA CA loops.
+**Action:** When implementing new queries over chunks that are used in hot CA loops, identify whether the aggregate can be pre-calculated and cached per-tick in the respective snapshot system.

--- a/crates/sim-fluid/src/snapshot.rs
+++ b/crates/sim-fluid/src/snapshot.rs
@@ -15,6 +15,7 @@ pub struct LiquidSnapshot {
     kinds: HashMap<ChunkCoord, Box<[LiquidId; CHUNK_AREA]>>,
     terrain: HashMap<ChunkCoord, Box<[MaterialId; CHUNK_AREA]>>,
     pressures: HashMap<ChunkCoord, Box<[u8; CHUNK_AREA]>>,
+    has_liquid: std::collections::HashSet<ChunkCoord>,
 }
 
 impl LiquidSnapshot {
@@ -38,9 +39,7 @@ impl LiquidSnapshot {
 
     /// True if chunk exists in snapshot and has any non-zero liquid amount.
     pub fn chunk_has_liquid(&self, coord: ChunkCoord) -> bool {
-        self.amounts
-            .get(&coord)
-            .is_some_and(|a| a.iter().any(|&v| v > 0))
+        self.has_liquid.contains(&coord)
     }
 
     /// True if any of the 4 horizontal neighbor chunks exist in the snapshot.
@@ -111,6 +110,7 @@ impl LiquidSnapshot {
 /// avoiding ~4 Box alloc/dealloc per chunk per tick.
 pub fn snapshot_liquid(mut snapshot: ResMut<LiquidSnapshot>, chunks: Query<&ChunkData>) {
     let mut seen = std::collections::HashSet::with_capacity(chunks.iter().len());
+    snapshot.has_liquid.clear();
 
     for chunk in chunks.iter() {
         seen.insert(chunk.coord);
@@ -138,6 +138,10 @@ pub fn snapshot_liquid(mut snapshot: ResMut<LiquidSnapshot>, chunks: Query<&Chun
             .entry(chunk.coord)
             .or_insert_with(|| Box::new([0u8; CHUNK_AREA]))
             .copy_from_slice(&*chunk.pressure_read);
+
+        if chunk.liquid_amount_read.iter().any(|&v| v > 0) {
+            snapshot.has_liquid.insert(chunk.coord);
+        }
     }
 
     // Remove entries for chunks that no longer exist.


### PR DESCRIPTION
💡 What: Added a `has_liquid` HashSet cache to `LiquidSnapshot` populated once during `snapshot_liquid`. `chunk_has_liquid` was updated to perform an `O(1)` `.contains()` check against the set.
🎯 Why: Iterating over 1024 tile slices repeatedly in CA loop conditions across thousands of chunks can be a significant bottleneck, causing redundant slice scans.
📊 Impact: Expected to provide a significant speedup in hot liquid loops, replacing `O(N)` scans with `O(1)` coordinate checks.
🔬 Measurement: Performance improvements can be measured in `sim-fluid` step times. Pre-commit tests and lint checks pass cleanly.

---
*PR created automatically by Jules for task [17434499110795618303](https://jules.google.com/task/17434499110795618303) started by @Pappet*