### PR TITLE
⚡ Bolt: Optimize periodic reaction system nested loops

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-25 - Pre-filter active reactions outside hot chunk loop
+**Learning:** In the voxel simulation, checking `every_ticks` for periodic reactions inside the nested `chunks.iter()` -> `reactions` loop causes redundant registry lookups and trigger evaluation for every chunk. Since periodic triggers are uniform across all chunks for a given tick, this can be pre-calculated.
+**Action:** Pre-filter active registry entries into a `Vec` outside of hot chunk/tile loops to reduce redundant work from O(Chunks * TotalReactions) to O(TotalReactions + Chunks * ActiveReactions).

--- a/crates/sim-reaction/src/resolver.rs
+++ b/crates/sim-reaction/src/resolver.rs
@@ -165,23 +165,27 @@ pub fn periodic_reaction_system(
         return;
     }
 
+    // Bolt: Pre-filter active reactions outside the hot loop to avoid redundant O(Chunks * TotalReactions) lookups.
+    // This reduces the complexity to O(TotalReactions + Chunks * ActiveReactions).
+    let mut active_reactions = Vec::with_capacity(periodic_ids.len());
+    for rid in periodic_ids {
+        if let Some(reaction) = registry.get(*rid) {
+            if let crate::Trigger::Periodic { every_ticks } = reaction.trigger {
+                if every_ticks == 0 || tick.is_multiple_of(every_ticks as u64) {
+                    active_reactions.push((*rid, reaction));
+                }
+            }
+        }
+    }
+
+    if active_reactions.is_empty() {
+        return;
+    }
+
     // Phase 1: collect pending effects (immutable chunk reads).
     for chunk in chunks.iter() {
         let coord = chunk.coord;
-        for rid in periodic_ids {
-            let reaction = match registry.get(*rid) {
-                Some(r) => r,
-                None => continue,
-            };
-
-            // Periodic phase-offset: skip ticks where (tick % every_ticks) != 0.
-            let crate::Trigger::Periodic { every_ticks } = reaction.trigger else {
-                continue;
-            };
-            if every_ticks > 0 && !tick.is_multiple_of(every_ticks as u64) {
-                continue;
-            }
-
+        for (rid, reaction) in &active_reactions {
             for idx in 0..tile_core::coords::CHUNK_AREA {
                 if let Some(min_t) = reaction.min_temperature
                     && chunk.temp[idx] < min_t


### PR DESCRIPTION
💡 What: Pre-filter active periodic reactions for the current tick before iterating through the chunks in `periodic_reaction_system`.
🎯 Why: The original logic looked up registry entries and evaluated periodic triggers (using `tick % every_ticks`) inside a highly nested loop (over every chunk, for every periodic reaction ID). This caused massive redundant work because the tick conditions and reaction metadata are uniform across all chunks for a given tick.
📊 Impact: Reduces algorithmic complexity of the system setup phase from O(Chunks * TotalReactions) to O(TotalReactions + Chunks * ActiveReactions), significantly improving tick execution time when many chunks and periodic reactions exist.
🔬 Measurement: Verify tests run via `cargo test -p sim-reaction`, and run the app to ensure reactions still fire appropriately.

---
*PR created automatically by Jules for task [6313244077125058895](https://jules.google.com/task/6313244077125058895) started by @Pappet*