### PR TITLE
perf(sim): fluid/reaction optimizations (has_liquid cache, slice borrows, reaction pre-filter)

### DIFF
--- a/crates/sim-fluid/src/fluid_ca.rs
+++ b/crates/sim-fluid/src/fluid_ca.rs
@@ -63,8 +63,7 @@ pub fn flow_with_pressure(
 pub fn pressure_propagation(mut chunks: Query<&mut ChunkData>, snapshot: Res<LiquidSnapshot>) {
     for mut chunk in chunks.iter_mut() {
         let coord = chunk.coord;
-        let has_liquid = chunk.liquid_amount_read.iter().any(|&a| a > 0);
-        if !has_liquid && !snapshot.has_any_neighbor_with_liquid(coord) {
+        if !snapshot.chunk_has_liquid(coord) && !snapshot.has_any_neighbor_with_liquid(coord) {
             chunk.pressure_write.fill(0);
             continue;
         }
@@ -171,15 +170,12 @@ pub fn fluid_step_local(
 ) {
     for mut chunk in chunks.iter_mut() {
         let coord = chunk.coord;
-        let has_liquid = chunk.liquid_amount_read.iter().any(|&a| a > 0);
-        if !has_liquid && !snapshot.has_any_neighbor(coord) {
+        if !snapshot.chunk_has_liquid(coord) && !snapshot.has_any_neighbor(coord) {
             continue;
         }
 
-        let mut amounts = [0u8; CHUNK_AREA];
-        amounts.copy_from_slice(&*chunk.liquid_amount_read);
-        let mut pressures = [0u8; CHUNK_AREA];
-        pressures.copy_from_slice(&*chunk.pressure_read);
+        let amounts = &*chunk.liquid_amount_read;
+        let pressures = &*chunk.pressure_read;
         let mut deltas = [0i16; CHUNK_AREA];
 
         // ── Intra-chunk: right + down pairs only ─────────────────────────
@@ -254,8 +250,8 @@ pub fn fluid_step_local(
                 r_our,
                 right,
                 r_nb,
-                &amounts,
-                &pressures,
+                amounts,
+                pressures,
                 &chunk.liquid_kind,
                 &chunk.terrain,
                 &snapshot,
@@ -270,8 +266,8 @@ pub fn fluid_step_local(
                 l_our,
                 left,
                 l_nb,
-                &amounts,
-                &pressures,
+                amounts,
+                pressures,
                 &chunk.liquid_kind,
                 &chunk.terrain,
                 &snapshot,
@@ -287,8 +283,8 @@ pub fn fluid_step_local(
                 d_our,
                 down,
                 d_nb,
-                &amounts,
-                &pressures,
+                amounts,
+                pressures,
                 &chunk.liquid_kind,
                 &chunk.terrain,
                 &snapshot,
@@ -303,8 +299,8 @@ pub fn fluid_step_local(
                 u_our,
                 up,
                 u_nb,
-                &amounts,
-                &pressures,
+                amounts,
+                pressures,
                 &chunk.liquid_kind,
                 &chunk.terrain,
                 &snapshot,

--- a/crates/sim-fluid/src/snapshot.rs
+++ b/crates/sim-fluid/src/snapshot.rs
@@ -1,5 +1,5 @@
 use bevy_ecs::prelude::*;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use tile_core::chunk::ChunkData;
 use tile_core::coords::{CHUNK_AREA, ChunkCoord};
 use tile_core::liquid::{LIQ_NONE, LiquidId};
@@ -15,6 +15,7 @@ pub struct LiquidSnapshot {
     kinds: HashMap<ChunkCoord, Box<[LiquidId; CHUNK_AREA]>>,
     terrain: HashMap<ChunkCoord, Box<[MaterialId; CHUNK_AREA]>>,
     pressures: HashMap<ChunkCoord, Box<[u8; CHUNK_AREA]>>,
+    has_liquid: HashSet<ChunkCoord>,
 }
 
 impl LiquidSnapshot {
@@ -38,9 +39,7 @@ impl LiquidSnapshot {
 
     /// True if chunk exists in snapshot and has any non-zero liquid amount.
     pub fn chunk_has_liquid(&self, coord: ChunkCoord) -> bool {
-        self.amounts
-            .get(&coord)
-            .is_some_and(|a| a.iter().any(|&v| v > 0))
+        self.has_liquid.contains(&coord)
     }
 
     /// True if any of the 4 horizontal neighbor chunks exist in the snapshot.
@@ -138,6 +137,12 @@ pub fn snapshot_liquid(mut snapshot: ResMut<LiquidSnapshot>, chunks: Query<&Chun
             .entry(chunk.coord)
             .or_insert_with(|| Box::new([0u8; CHUNK_AREA]))
             .copy_from_slice(&*chunk.pressure_read);
+
+        if chunk.liquid_amount_read.iter().any(|&a| a > 0) {
+            snapshot.has_liquid.insert(chunk.coord);
+        } else {
+            snapshot.has_liquid.remove(&chunk.coord);
+        }
     }
 
     // Remove entries for chunks that no longer exist.
@@ -145,4 +150,5 @@ pub fn snapshot_liquid(mut snapshot: ResMut<LiquidSnapshot>, chunks: Query<&Chun
     snapshot.kinds.retain(|k, _| seen.contains(k));
     snapshot.terrain.retain(|k, _| seen.contains(k));
     snapshot.pressures.retain(|k, _| seen.contains(k));
+    snapshot.has_liquid.retain(|k| seen.contains(k));
 }

--- a/crates/sim-fluid/src/vertical_flow.rs
+++ b/crates/sim-fluid/src/vertical_flow.rs
@@ -26,7 +26,6 @@ pub fn liquid_vertical_flow(
 ) {
     for mut chunk in chunks.iter_mut() {
         let coord = chunk.coord;
-        let has_liquid = chunk.liquid_amount_read.iter().any(|&a| a > 0);
 
         // Check if chunk above has liquid that could fall into us
         let above = ChunkCoord {
@@ -39,12 +38,11 @@ pub fn liquid_vertical_flow(
         };
         let above_has_liquid = snapshot.chunk_has_liquid(above);
 
-        if !has_liquid && !above_has_liquid {
+        if !snapshot.chunk_has_liquid(coord) && !above_has_liquid {
             continue;
         }
 
-        let mut amounts = [0u8; CHUNK_AREA];
-        amounts.copy_from_slice(&*chunk.liquid_amount_read);
+        let amounts = &*chunk.liquid_amount_read;
         let mut amount_deltas = [0i16; CHUNK_AREA];
         // Track per-tile kind changes from vertical flow. None = unchanged.
         let mut kind_change: [Option<LiquidId>; CHUNK_AREA] = [None; CHUNK_AREA];

--- a/crates/sim-reaction/src/resolver.rs
+++ b/crates/sim-reaction/src/resolver.rs
@@ -168,12 +168,11 @@ pub fn periodic_reaction_system(
     // Pre-filter to only reactions that fire this tick, avoiding O(Chunks * TotalReactions).
     let mut active_reactions = Vec::with_capacity(periodic_ids.len());
     for rid in periodic_ids {
-        if let Some(reaction) = registry.get(*rid) {
-            if let crate::Trigger::Periodic { every_ticks } = reaction.trigger {
-                if every_ticks == 0 || tick.is_multiple_of(every_ticks as u64) {
-                    active_reactions.push((*rid, reaction));
-                }
-            }
+        if let Some(reaction) = registry.get(*rid)
+            && let crate::Trigger::Periodic { every_ticks } = reaction.trigger
+            && (every_ticks == 0 || tick.is_multiple_of(every_ticks as u64))
+        {
+            active_reactions.push((*rid, reaction));
         }
     }
     if active_reactions.is_empty() {

--- a/crates/sim-reaction/src/resolver.rs
+++ b/crates/sim-reaction/src/resolver.rs
@@ -165,23 +165,25 @@ pub fn periodic_reaction_system(
         return;
     }
 
+    // Pre-filter to only reactions that fire this tick, avoiding O(Chunks * TotalReactions).
+    let mut active_reactions = Vec::with_capacity(periodic_ids.len());
+    for rid in periodic_ids {
+        if let Some(reaction) = registry.get(*rid) {
+            if let crate::Trigger::Periodic { every_ticks } = reaction.trigger {
+                if every_ticks == 0 || tick.is_multiple_of(every_ticks as u64) {
+                    active_reactions.push((*rid, reaction));
+                }
+            }
+        }
+    }
+    if active_reactions.is_empty() {
+        return;
+    }
+
     // Phase 1: collect pending effects (immutable chunk reads).
     for chunk in chunks.iter() {
         let coord = chunk.coord;
-        for rid in periodic_ids {
-            let reaction = match registry.get(*rid) {
-                Some(r) => r,
-                None => continue,
-            };
-
-            // Periodic phase-offset: skip ticks where (tick % every_ticks) != 0.
-            let crate::Trigger::Periodic { every_ticks } = reaction.trigger else {
-                continue;
-            };
-            if every_ticks > 0 && !tick.is_multiple_of(every_ticks as u64) {
-                continue;
-            }
-
+        for (rid, reaction) in &active_reactions {
             for idx in 0..tile_core::coords::CHUNK_AREA {
                 if let Some(min_t) = reaction.min_temperature
                     && chunk.temp[idx] < min_t


### PR DESCRIPTION
## Summary

Three orthogonal, conflict-free performance optimizations consolidated from the Jules PR flood:

- **`has_liquid` cache in `LiquidSnapshot`** — adds a `HashSet<ChunkCoord>` populated once per tick in `snapshot_liquid`. Replaces repeated O(1024) `.iter().any()` scans in `pressure_propagation`, `fluid_step_local`, and `liquid_vertical_flow` with an O(1) set lookup. Also fixes the pre-existing O(N) scan inside `chunk_has_liquid` in the snapshot itself.

- **Slice borrows instead of stack copies** — `fluid_step_local` and `liquid_vertical_flow` previously copied `liquid_amount_read` and `pressure_read` into 1 KB stack arrays before reading them. Replaced with direct `&*` borrows; no copy needed since these buffers are read-only within a tick.

- **Periodic reaction pre-filtering** — `periodic_reaction_system` now builds an `active_reactions` vec (with pre-allocated capacity) outside the chunk loop, reducing complexity from O(Chunks × TotalReactions) to O(TotalReactions + Chunks × ActiveReactions).

## Test plan

- [x] `cargo test -p sim_fluid -p sim-reaction` — 31/31 tests pass (U-pipe, mass conservation, vertical flow, periodic phase-offset, determinism)
- [x] `cargo clippy` + `cargo fmt --check` — clean
- [x] CI green (Build, Test, Lint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)