### PR TITLE
⚡ Bolt: Add `#[inline]` to hot-path math functions

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-05-30 - Cross-Crate Inlining of Hot-Path Math Functions
+**Learning:** Small, frequently called math and utility functions (such as `mix_hash` and coordinate conversions in `crates/core`) that are used across crate boundaries in simulation hot paths must be explicitly marked `#[inline]` to guarantee cross-crate inlining by LLVM. Without this, the overhead of function calls across crates can significantly impact performance in tight inner loops, which is exactly where these math functions are typically used.
+**Action:** Always ensure that small, stateless functions on critical paths, especially those exported across workspace crates, are decorated with `#[inline]` (or `#[inline(always)]` if appropriate).

--- a/crates/core/src/coords.rs
+++ b/crates/core/src/coords.rs
@@ -26,6 +26,7 @@ pub struct LocalPos {
 }
 
 impl WorldPos {
+    #[inline]
     pub fn split(self) -> (ChunkCoord, LocalPos) {
         let cc = ChunkCoord {
             cx: self.x >> CHUNK_SHIFT,
@@ -41,6 +42,7 @@ impl WorldPos {
 }
 
 impl ChunkCoord {
+    #[inline]
     pub fn world_pos(self, lp: LocalPos) -> WorldPos {
         WorldPos {
             x: (self.cx << CHUNK_SHIFT) | (lp.lx as i32),
@@ -51,10 +53,12 @@ impl ChunkCoord {
 }
 
 impl LocalPos {
+    #[inline]
     pub fn index(self) -> usize {
         (self.ly as usize) * CHUNK_SIZE + (self.lx as usize)
     }
 
+    #[inline]
     pub fn from_index(index: usize) -> Self {
         debug_assert!(index < CHUNK_AREA);
         LocalPos {

--- a/crates/core/src/rng.rs
+++ b/crates/core/src/rng.rs
@@ -4,6 +4,7 @@ use crate::coords::ChunkCoord;
 ///
 /// Mixes coord + tile index + tick + reaction ID using finalizer from
 /// splitmix64. No global state — parallel-safe and reproducible.
+#[inline]
 pub fn mix_hash(coord: ChunkCoord, idx: usize, tick: u64, rid: u32) -> u64 {
     let mut h: u64 = 0xcafef00dd15ea5e5;
     h ^= (coord.cx as i64 as u64).wrapping_mul(0x9e3779b97f4a7c15);


### PR DESCRIPTION
💡 What: Added `#[inline]` to small, stateless math and coordinate conversion functions (like `mix_hash` and `LocalPos::index`) in `crates/core`.

🎯 Why: These functions are frequently called across crate boundaries within the tightest inner loops of the simulation (e.g., iterating through every tile in a chunk). Without `#[inline]`, LLVM might not inline these function calls across crates (especially without LTO), adding significant function-call overhead to the simulation hot path.

📊 Impact: Reduces function call overhead across crate boundaries in the simulation hot path.

🔬 Measurement: Verify tests still pass using `cargo test --workspace` and use a profiler (like `puffin` via `cargo run -p app --features profile`) to observe reduced overhead in simulation systems making heavy use of `mix_hash` or coordinate math.

---
*PR created automatically by Jules for task [18192812165474018799](https://jules.google.com/task/18192812165474018799) started by @Pappet*