### PR TITLE
⚡ Bolt: Optimize mix_hash inlining and short-circuit probability rolls

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-06-02 - Inline `mix_hash` and Short-circuit Probability Rolls
+**Learning:** Small, frequently called math functions like `mix_hash` (used across crate boundaries in hot simulation loops) aren't automatically inlined by rustc across crates, adding significant call overhead. Additionally, expensive dynamic condition evaluations in CA updates were being performed before cheap stateless probability checks, wasting computation on events that would ultimately fail their probability roll.
+**Action:** Always add `#[inline]` to cross-crate hot-path functions, and restructure simulation logic to evaluate cheap stateless probability checks before expensive dynamic data reads to enable early short-circuiting.

--- a/crates/core/src/rng.rs
+++ b/crates/core/src/rng.rs
@@ -4,6 +4,7 @@ use crate::coords::ChunkCoord;
 ///
 /// Mixes coord + tile index + tick + reaction ID using finalizer from
 /// splitmix64. No global state — parallel-safe and reproducible.
+#[inline]
 pub fn mix_hash(coord: ChunkCoord, idx: usize, tick: u64, rid: u32) -> u64 {
     let mut h: u64 = 0xcafef00dd15ea5e5;
     h ^= (coord.cx as i64 as u64).wrapping_mul(0x9e3779b97f4a7c15);

--- a/crates/sim-reaction/src/resolver.rs
+++ b/crates/sim-reaction/src/resolver.rs
@@ -195,6 +195,14 @@ pub fn periodic_reaction_system(
                     continue;
                 }
 
+                // Probability roll (cheap stateless check first to short-circuit).
+                if reaction.probability < u16::MAX {
+                    let h = mix_hash(coord, idx, tick, rid.0);
+                    if (h & 0xFFFF) >= reaction.probability as u64 {
+                        continue;
+                    }
+                }
+
                 // Evaluate conditions (no incoming liquid for Periodic).
                 if !reaction
                     .conditions
@@ -202,14 +210,6 @@ pub fn periodic_reaction_system(
                     .all(|c| evaluate(c, chunk, idx, &material_reg, &liquid_reg, None))
                 {
                     continue;
-                }
-
-                // Probability roll.
-                if reaction.probability < u16::MAX {
-                    let h = mix_hash(coord, idx, tick, rid.0);
-                    if (h & 0xFFFF) >= reaction.probability as u64 {
-                        continue;
-                    }
                 }
 
                 pending.buffer.push(PendingEffect {
@@ -276,6 +276,14 @@ pub fn liquid_collision_reaction_system(
                 None => continue,
             };
 
+            // Probability roll (cheap stateless check first to short-circuit).
+            if reaction.probability < u16::MAX {
+                let h = mix_hash(event.coord, event.idx, tick, rid.0);
+                if (h & 0xFFFF) >= reaction.probability as u64 {
+                    continue;
+                }
+            }
+
             if !reaction.conditions.iter().all(|c| {
                 evaluate(
                     c,
@@ -287,13 +295,6 @@ pub fn liquid_collision_reaction_system(
                 )
             }) {
                 continue;
-            }
-
-            if reaction.probability < u16::MAX {
-                let h = mix_hash(event.coord, event.idx, tick, rid.0);
-                if (h & 0xFFFF) >= reaction.probability as u64 {
-                    continue;
-                }
             }
 
             let effects = reaction.effects.clone();


### PR DESCRIPTION
💡 What: Adds `#[inline]` to `mix_hash` and moves probability rolls to short-circuit before expensive memory reads.
🎯 Why: Small math functions like `mix_hash` aren't auto-inlined across crates and add overhead. Evaluating expensive dynamic conditions before cheap stateless probability checks wastes computation on events that would fail the probability roll anyway.
📊 Impact: Reduces function call overhead and prevents unnecessary memory reads and condition evaluations for low-probability events in hot simulation loops.
🔬 Measurement: Verified with `cargo test` and `cargo fmt`. Can be benchmarked using profiling tools to observe reduced overhead in `periodic_reaction_system` and `liquid_collision_reaction_system`.

---
*PR created automatically by Jules for task [17879686887260042831](https://jules.google.com/task/17879686887260042831) started by @Pappet*