### PR TITLE
⚡ Bolt: Add #[inline] to hot math function mix_hash

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-06-04 - Mark mix_hash function #[inline] to eliminate function call overhead across boundaries
+**Learning:** Small, frequently called math functions like `mix_hash` that are heavily utilized across multiple crates in simulation hot paths suffer from function call overhead because Rust does not cross-crate inline them automatically by default.
+**Action:** Always explicitly add the `#[inline]` attribute to frequently used utility functions shared between crates in hot paths.

--- a/crates/core/src/rng.rs
+++ b/crates/core/src/rng.rs
@@ -4,6 +4,7 @@ use crate::coords::ChunkCoord;
 ///
 /// Mixes coord + tile index + tick + reaction ID using finalizer from
 /// splitmix64. No global state — parallel-safe and reproducible.
+#[inline]
 pub fn mix_hash(coord: ChunkCoord, idx: usize, tick: u64, rid: u32) -> u64 {
     let mut h: u64 = 0xcafef00dd15ea5e5;
     h ^= (coord.cx as i64 as u64).wrapping_mul(0x9e3779b97f4a7c15);


### PR DESCRIPTION
💡 What: Added the `#[inline]` attribute to the heavily used `mix_hash` function in `crates/core/src/rng.rs`.
🎯 Why: `mix_hash` is a small, frequently called utility function utilized heavily across different crates in simulation hot paths (e.g., `sim-reaction`). Without `#[inline]`, Rust does not cross-crate inline it by default, causing unnecessary function call overhead.
📊 Impact: Removes the cross-crate function call overhead for millions of calls per tick in hot simulation paths. Allows LLVM to inline and further optimize the logic inside the caller context.
🔬 Measurement: Verify changes in generated assembly, or profile the simulation hot loop (like `sim-reaction`) with tools like tracy to confirm the call overhead has been eliminated.

---
*PR created automatically by Jules for task [9808277905212641322](https://jules.google.com/task/9808277905212641322) started by @Pappet*