### PR TITLE
⚡ Bolt: [Inline cross-crate mix_hash]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-06-06 - [Cross-crate function inlining]
+**Learning:** Small, frequently called math functions (such as `mix_hash`) used across crate boundaries in simulation hot paths must be explicitly marked `#[inline]` to guarantee cross-crate inlining and avoid function call overhead.
+**Action:** Always verify cross-crate function usage and apply `#[inline]` where it's called frequently in performance-critical paths.

--- a/crates/core/src/rng.rs
+++ b/crates/core/src/rng.rs
@@ -4,6 +4,9 @@ use crate::coords::ChunkCoord;
 ///
 /// Mixes coord + tile index + tick + reaction ID using finalizer from
 /// splitmix64. No global state — parallel-safe and reproducible.
+/// Note: #[inline] is strictly required because this function is called
+/// per-tile in hot chunk loops from other crates (like sim-reaction).
+#[inline]
 pub fn mix_hash(coord: ChunkCoord, idx: usize, tick: u64, rid: u32) -> u64 {
     let mut h: u64 = 0xcafef00dd15ea5e5;
     h ^= (coord.cx as i64 as u64).wrapping_mul(0x9e3779b97f4a7c15);


### PR DESCRIPTION
💡 What: Added `#[inline]` to `mix_hash` in `crates/core/src/rng.rs` and documented it in `.jules/bolt.md`.
🎯 Why: `mix_hash` is called per-tile from hot chunk loops in other crates like `sim-reaction`. Without explicit `#[inline]`, it suffers cross-crate function call overhead.
📊 Impact: Eliminates cross-crate function call overhead in hot paths involving randomness or hash rolls across the simulation.
🔬 Measurement: Verify compiled binary instruction size reduction or measure cycle times in functions making heavy use of `mix_hash`.

---
*PR created automatically by Jules for task [10707281818152328014](https://jules.google.com/task/10707281818152328014) started by @Pappet*