### PR TITLE
⚡ Bolt: Inline mix_hash for performance

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-06-07 - Inline Random Number Generation
+**Learning:** `mix_hash` in `crates/core/src/rng.rs` is highly utilized across crates for procedural randomness. Not marking it `#[inline]` prevents the compiler from inlining it across crates, leading to significant function call overhead in the hot loop.
+**Action:** Always verify `#[inline]` on short mathematical functions used globally and primarily in tight simulation loops.

--- a/crates/core/src/rng.rs
+++ b/crates/core/src/rng.rs
@@ -4,6 +4,7 @@ use crate::coords::ChunkCoord;
 ///
 /// Mixes coord + tile index + tick + reaction ID using finalizer from
 /// splitmix64. No global state — parallel-safe and reproducible.
+#[inline]
 pub fn mix_hash(coord: ChunkCoord, idx: usize, tick: u64, rid: u32) -> u64 {
     let mut h: u64 = 0xcafef00dd15ea5e5;
     h ^= (coord.cx as i64 as u64).wrapping_mul(0x9e3779b97f4a7c15);


### PR DESCRIPTION
💡 What: Added `#[inline]` to the `mix_hash` function in `crates/core/src/rng.rs` and documented the learning in `.jules/bolt.md`.
🎯 Why: `mix_hash` is highly utilized across crates for procedural randomness. Not marking it `#[inline]` prevents the compiler from inlining it across crates, leading to significant function call overhead in the hot loop.
📊 Impact: Reduces function call overhead in the hot simulation loops where randomness is used.
🔬 Measurement: Verify tests still pass with `cargo test` and format with `cargo fmt`.

---
*PR created automatically by Jules for task [9012384418063839045](https://jules.google.com/task/9012384418063839045) started by @Pappet*