### PR TITLE
⚡ Bolt: Inline mix_hash for cross-crate optimization

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-06-10 - Cross-Crate Inlining
+**Learning:** Small, frequently called math functions (such as `mix_hash`) used across crate boundaries in simulation hot paths are not automatically inlined by the compiler across crates, which can lead to unnecessary function call overhead.
+**Action:** Always explicitly mark such functions with `#[inline]` to guarantee cross-crate inlining and avoid function call overhead.

--- a/crates/core/src/rng.rs
+++ b/crates/core/src/rng.rs
@@ -4,6 +4,7 @@ use crate::coords::ChunkCoord;
 ///
 /// Mixes coord + tile index + tick + reaction ID using finalizer from
 /// splitmix64. No global state — parallel-safe and reproducible.
+#[inline]
 pub fn mix_hash(coord: ChunkCoord, idx: usize, tick: u64, rid: u32) -> u64 {
     let mut h: u64 = 0xcafef00dd15ea5e5;
     h ^= (coord.cx as i64 as u64).wrapping_mul(0x9e3779b97f4a7c15);


### PR DESCRIPTION
💡 **What:** Added the `#[inline]` attribute to the `mix_hash` function in `crates/core/src/rng.rs`.
🎯 **Why:** `mix_hash` is a small, frequently called mathematical function used in simulation hot paths. Without the `#[inline]` attribute, Rust does not inline functions across crate boundaries, leading to unnecessary function call overhead when `mix_hash` is invoked from other crates in the workspace (like `sim-reaction`).
📊 **Impact:** Eliminates function call overhead for all cross-crate invocations of `mix_hash`, improving performance in hot simulation loops that rely on random hashing.
🔬 **Measurement:** Verify by compiling with optimizations (`cargo run --release`) and inspecting performance profiles using `puffin` or `tracy`.

---
*PR created automatically by Jules for task [8283849620121792006](https://jules.google.com/task/8283849620121792006) started by @Pappet*