### PR TITLE
chore: fix clippy errors in test code

### DIFF
--- a/crates/persistence/src/save.rs
+++ b/crates/persistence/src/save.rs
@@ -205,8 +205,10 @@ mod tests {
     }
 
     fn make_world_with_chunks(chunks: &[(ChunkCoord, Entity)]) -> World {
-        let mut w = World::default();
-        w.current_tick = 42;
+        let mut w = World {
+            current_tick: 42,
+            ..Default::default()
+        };
         for (coord, entity) in chunks {
             w.chunks.insert(*coord, *entity);
         }

--- a/crates/sim-fluid/src/fluid_ca.rs
+++ b/crates/sim-fluid/src/fluid_ca.rs
@@ -753,6 +753,8 @@ mod tests {
     /// Liquid spreads along connector row then fills right column.
     /// After N ticks both columns equalize within ±3 total.
     #[test]
+    // `0 * CHUNK_SIZE` / `1 * CHUNK_SIZE` spell out the row index for readability.
+    #[allow(clippy::erasing_op, clippy::identity_op)]
     fn test_u_pipe_equalizes() {
         let mut app = make_app_with_pressure();
         let coord = ChunkCoord {


### PR DESCRIPTION
## Zusammenfassung

Verifikationsdurchlauf des aktuellen Stands (Phase 14). Build und Tests sind grün (75 Tests, 0 Fehler); dieser PR behebt die letzten Clippy-Findings, damit `cargo clippy --workspace --all-targets` ohne Fehler und Warnungen durchläuft:

- `sim-fluid/src/fluid_ca.rs`: `#[allow(clippy::erasing_op, clippy::identity_op)]` am U-Pipe-Test — die `0 * CHUNK_SIZE`-Schreibweise ist dort bewusst gewählt, um die Zeilenindizes lesbar zu halten (deny-by-default-Lint `erasing_op` schlug fehl).
- `persistence/src/save.rs`: Struct-Initializer statt Feldzuweisung nach `Default::default()` (`field_reassign_with_default`).

## Hinweis aus der Verifikation

Die im Audit (`docs/CODE_AUDIT.md`, #70) dokumentierten Cross-Module-Befunde (#58–#69) sind weiterhin offen und nicht Teil dieses PRs — insbesondere B1 (kein `SimSet`/`FixedUpdate`) wurde im Code erneut bestätigt.

## Test

- `cargo test --workspace` — 75 passed, 0 failed
- `cargo clippy --workspace --all-targets` — 0 warnings/errors

https://claude.ai/code/session_01GhAoQidSFRh2NMhPtmVYm1

---
_Generated by [Claude Code](https://claude.ai/code/session_01GhAoQidSFRh2NMhPtmVYm1)_